### PR TITLE
Watch provider crd to run managedcluster

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Unit test
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
@@ -21,7 +21,6 @@ jobs:
         run: |
           go mod tidy
           make test
-         
   webhook-test:
     runs-on: ubuntu-latest
     env:
@@ -40,3 +39,36 @@ jobs:
           export CONTAINER_TOOL=docker
           make prepare-webhook-test
           make run-webhook-test
+          
+  e2e-test:
+    runs-on: ubuntu-latest
+    env:
+      KIND_NAME: kind-cluster
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Running Tests
+        run: |
+          make prepare-e2e-test
+          make run-e2e-test
+
+  sonarcloud:
+    runs-on: ubuntu-latest
+    needs:
+      - e2e-test
+      - webhook-test
+      - test
+    steps:
+      - run: echo "Running SonarCloud analysis..."
+      - name: Upload artifacts for the sonarcloud workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: |
+            coverage*.out
+            report*.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,14 @@ ca.srl
 user1.crt
 user1.key
 user1.csr
+tls.crt
+tls.key
 
 kubeconfig_e2e
+mtv_integrations_instrumented
+
+report_*.json
+
+coverage_profiles/*
+
+dist/*

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,7 @@ import (
 
 	forkliftv1beta1 "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -58,6 +59,7 @@ func init() {
 	utilruntime.Must(auth.AddToScheme(scheme))
 	utilruntime.Must(forkliftv1beta1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(authorizationv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,3 +24,6 @@ rules:
 - apiGroups: [""]
   resources: ["users", "groups", "serviceaccounts"]
   verbs: ["impersonate"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
+  verbs: ["get","list","watch"]

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.33.0
-	k8s.io/apiextensions-apiserver v0.33.0 // indirect
+	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apiserver v0.33.0 // indirect
 	k8s.io/component-base v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,5 @@
 sonar.projectKey=open-cluster-management_mtv-integrations
 sonar.projectName=mtv-integrations
 sonar.exclusions=**/webhook/**,**/test/**
+sonar.go.coverage.reportPaths=coverage_e2e.out,coverage_unit.out
+sonar.go.tests.reportPaths=report_webhook.json,report_e2e.json,report_unit.json

--- a/test/e2e/managedcluster_provider_crd_test.go
+++ b/test/e2e/managedcluster_provider_crd_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stolostron/mtv-integrations/test/utils"
+)
+
+var _ = Describe("Test crd controller", Ordered, func() {
+	const (
+		path               string = "../resources/managedcluster_provider_crd"
+		providerCrdPath    string = path + "/provider_crd.yaml"
+		managedclusterPath string = path + "/managedcluster.yaml"
+		namespace          string = "mtv-integrations"
+	)
+
+	AfterEach(func() {
+		By("Clean log file")
+		err := utils.EmptyLogFile()
+		Expect(err).ToNot(HaveOccurred(), "Failed to empty log file")
+	})
+
+	BeforeAll(func() {
+		utils.Kubectl("apply", "-f", managedclusterPath)
+	})
+	It("Should not start managedcluster controller", func() {
+		Consistently(func() bool {
+			return utils.FindLogMessage("Reconciling ManagedCluster")
+		}, 10).Should(BeFalse(),
+			"ManagedCluster controller should not reconcile without Provider CRD")
+	})
+
+	It("Should reconcile managedcluster after Provider CRD provided", func() {
+		utils.Kubectl("apply", "-f", providerCrdPath)
+		DeferCleanup(func() {
+			By("Clean up the Provider CRD")
+			utils.Kubectl("delete", "-f", providerCrdPath, "--ignore-not-found")
+		})
+
+		Eventually(func() bool {
+			return utils.FindLogMessage("Reconciling ManagedCluster")
+		}, 30).Should(BeTrue(),
+			"ManagedCluster controller continues with Provider CRD")
+	})
+
+	It("Should not continue managedcluster controller after Provider CRD deleted", func() {
+		utils.Kubectl("delete", "-f", providerCrdPath, "--ignore-not-found")
+		DeferCleanup(func() {
+			By("Clean up the Provider CRD")
+			utils.Kubectl("delete", "-f", providerCrdPath, "--ignore-not-found")
+		})
+
+		Eventually(func() bool {
+			return utils.FindLogMessage("Provider CRD is not established, skipping reconciliation")
+		}, 30).Should(BeTrue(),
+			"ManagedCluster controller should skip with Provider CRD removed")
+	})
+
+	It("Should start again managedcluster controller after Provider CRD provided", func() {
+		utils.Kubectl("apply", "-f", providerCrdPath)
+		DeferCleanup(func() {
+			By("Clean up the Provider CRD")
+			utils.Kubectl("delete", "-f", providerCrdPath, "--ignore-not-found")
+		})
+
+		Eventually(func() bool {
+			return utils.FindLogMessage("Reconciling ManagedCluster")
+		}, 30).Should(BeTrue(),
+			"ManagedCluster controller should continue with Provider CRD")
+	})
+})

--- a/test/resources/managedcluster_provider_crd/managedcluster.yaml
+++ b/test/resources/managedcluster_provider_crd/managedcluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: cluster1
+spec:
+  hubAcceptsClient: true

--- a/test/resources/managedcluster_provider_crd/provider_crd.yaml
+++ b/test/resources/managedcluster_provider_crd/provider_crd.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: providers.forklift.konveyor.io
+spec:
+  group: forklift.konveyor.io
+  names:
+    kind: Provider
+    listKind: ProviderList
+    plural: providers
+    singular: provider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ConnectionTestSucceeded')].status
+      name: CONNECTED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='InventoryCreated')].status
+      name: INVENTORY
+      type: string
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of Provider.
+            properties:
+              secret:
+                description: |-
+                  References a secret containing credentials and
+                  other confidential information.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              settings:
+                additionalProperties:
+                  type: string
+                description: Provider settings.
+                type: object
+              type:
+                description: Provider type.
+                type: string
+              url:
+                description: |-
+                  The provider URL.
+                  Empty may be used for the `host` provider.
+                type: string
+            required:
+            - secret
+            - type
+            type: object
+          status:
+            description: ProviderStatus defines the observed state of Provider
+            properties:
+              conditions:
+                description: List of conditions.
+                items:
+                  description: Condition
+                  properties:
+                    category:
+                      description: The condition category.
+                      type: string
+                    durable:
+                      description: The condition is durable - never un-staged.
+                      type: boolean
+                    items:
+                      description: A list of items referenced in the `Message`.
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: When the last status transition occurred.
+                      format: date-time
+                      type: string
+                    message:
+                      description: The human readable description of the condition.
+                      type: string
+                    reason:
+                      description: The reason for the condition or transition.
+                      type: string
+                    status:
+                      description: The condition status [true,false].
+                      type: string
+                    type:
+                      description: The condition type.
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              fingerprint:
+                description: Fingerprint.
+                type: string
+              observedGeneration:
+                description: The most recent generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current life cycle phase of the provider.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -45,4 +47,54 @@ func KubectlWithOutput(args ...string) (string, error) {
 	}
 
 	return string(output), err
+}
+
+// FindLogMessage opens the file "e2e.log" and searches for the given message string.
+// It returns true if the message is found in any line of the file, otherwise false.
+func FindLogMessage(msg string) bool {
+	file, err := os.Open("../e2e/e2e.log")
+	if err != nil {
+		// Handle the error if the file cannot be opened.
+		// For an e2e log, it might mean the test hasn't run yet or the path is wrong.
+		fmt.Printf("Error opening e2e.log: %v\n", err)
+		return false
+	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil {
+			fmt.Printf("Warning: error closing file 'e2e.log': %v\n", cerr)
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, msg) {
+			return true // Message found
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		// Handle potential errors during scanning (e.g., I/O errors)
+		fmt.Printf("Error reading e2e.log: %v\n", err)
+	}
+
+	return false // Message not found after scanning the entire file
+}
+
+// EmptyLogFile truncates the specified file to zero length.
+// If the file does not exist, it creates an empty file.
+func EmptyLogFile() error {
+	// Open the file in write-only mode, create if it doesn't exist, and truncate its content.
+	file, err := os.OpenFile("../e2e/e2e.log", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open or create file %s for emptying: %w", "e2e.log", err)
+	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil {
+			fmt.Printf("Warning: error closing file 'e2e.log': %v\n", cerr)
+		}
+	}()
+
+	fmt.Printf("File '%s' has been emptied.\n", "e2e.log")
+	return nil
 }


### PR DESCRIPTION
### Feature: Dynamic Lifecycle Management for ManagedCluster Controller

**Problem:**

The `ManagedCluster` controller currently operates continuously, attempting to reconcile `ManagedCluster` resources regardless of the presence or readiness of its foundational dependency: the `Provider` CustomResourceDefinition (CRD). This behavior can lead to:

* **Resource Inefficiency:** The controller consumes CPU and memory for reconciliation and maintaining caches even when it cannot fully process `ManagedCluster` resources due to the absence of the `Provider` CRD.
* **Noisy Logs and looping:** Repeated errors or constant requeues related to the missing `Provider` CRD clutter logs.
API is not yet available.

**Solution:**

This PR introduces a robust, event-driven mechanism to dynamically control the operational lifecycle of the `ManagedCluster` controller. The controller will now automatically start when the `Provider` CRD becomes available and established, and gracefully stop when the `Provider` CRD is removed or no longer established.

**E2E test**
An E2E test has been added to verify the controller's dynamic behavior and prevent future regressions. This test specifically checks controller logs to ensure the ManagedCluster controller starts and stops as expected.


Ref: https://issues.redhat.com/browse/ACM-21706