### PR TITLE
Skip auth for non--mtv Providers in webhook

### DIFF
--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -48,4 +48,25 @@ var _ = Describe("Test webhook", func() {
 				utils.Kubectl("delete", "-f", planManaged1Path, "--ignore-not-found")
 			})
 		})
+
+	It("Should get success message from webhook when provider is not managed by MTV controller",
+		Label("webhook"), func() {
+			const planSuffixPath string = path + "/plan_no_mtv_suffix.yaml"
+			const planName string = "test-plan-1"
+
+			utils.Kubectl("create", "ns", ns)
+			DeferCleanup(func() {
+				By("Clean up the namespace")
+				utils.Kubectl("delete", "ns", ns, "--ignore-not-found")
+			})
+
+			output, _ := utils.KubectlWithOutput("apply", "-f", planSuffixPath, "--kubeconfig", "../../kubeconfig_e2e", "-n", ns)
+			DeferCleanup(func() {
+				By("Clean up the plan resource")
+				utils.Kubectl("delete", "-f", planSuffixPath, "--ignore-not-found")
+			})
+
+			//nolint:lll
+			Expect(output).Should(ContainSubstring("plan.forklift.konveyor.io/" + planName + " created"))
+		})
 })

--- a/test/resources/webhook/plan_managed1.yaml
+++ b/test/resources/webhook/plan_managed1.yaml
@@ -22,7 +22,7 @@ spec:
     destination:
       apiVersion: forklift.konveyor.io/v1beta1
       kind: Provider
-      name: managed1
+      name: managed1-mtv
       namespace: openshift-mtv
       uid: af5466a1-c3bd-4418-b7ec-40ed44fcec46
     source:

--- a/test/resources/webhook/plan_no_mtv_suffix.yaml
+++ b/test/resources/webhook/plan_no_mtv_suffix.yaml
@@ -1,7 +1,7 @@
 apiVersion: forklift.konveyor.io/v1beta1
 kind: Plan
 metadata:
-  name: test-plan
+  name: test-plan-1
   namespace: openshift-mtv
 spec:
   map:
@@ -22,7 +22,7 @@ spec:
     destination:
       apiVersion: forklift.konveyor.io/v1beta1
       kind: Provider
-      name: managed-empty-mtv
+      name: no-auth
       namespace: openshift-mtv
       uid: af5466a1-c3bd-4418-b7ec-40ed44fcec46
     source:


### PR DESCRIPTION
**Description**:
Currently, the mtv-integrations webhook checks authorization on the destination Provider for all Plans, regardless of how the Provider was created.This causes issues when a user manually creates a Provider and attempts to create a Plan using that Provider—authorization fails in this scenario.

To address this, update the webhook logic to only perform authorization checks if the destination Provider in the Plan was created by the mtv-integrations controller. These automatically created Providers have a -mtv suffix in their name.

This change ensures that manually created Providers are excluded from webhook authorization checks, allowing users to proceed with custom Plans.

**Acceptance Criteria**
- Suffix-Based Filtering
  The webhook must only perform authorization checks on destination Providers whose names end with -mtv.
- Skip Manual Providers
   If the destination Provider does not have the -mtv suffix (i.e., manually created), the webhook must skip the authorization          check.  
- No Impact to Existing Behavior
  Plans using -mtv Providers must continue to undergo authorization checks as before.
- Test Coverage
  Unit or integration tests must validate:
  Authorization is triggered for -mtv Providers.
  Authorization is skipped for non--mtv Providers.
Ref: https://issues.redhat.com/browse/ACM-22344