### PR TITLE
Add charts for Multicluster Hub Operator

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+appVersion: 2.12.0
+description: A Helm chart for multicloud mtv-integrations
+category: "Development"
+keywords:
+  - acm
+  - mtv
+  - cnv
+  - vm
+name: mtv-integrations
+verified: "RHACM"
+version: 2.12.0

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,2 @@
+This directory contains resources used in the chart automation process for the Multicluster Hub Operator.
+For more details, refer to the [multiclusterhub-operator repository](https://github.com/stolostron/multiclusterhub-operator).

--- a/charts/templates/cnv-addon-template.yaml
+++ b/charts/templates/cnv-addon-template.yaml
@@ -1,0 +1,110 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: kubevirt-hyperconverged-operator
+spec:
+  addonName: kubevirt-hyperconverged-operator
+  registration:
+    - type: CustomSigner
+      customSigner:
+        signerName: open-cluster-management.io/kubevirt-hyperconverged-addon
+        signingCA:
+          name: kubevirt-hyperconverged-ca
+          namespace: openshift-cnv
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: operatorpolicy-manager
+            namespace: open-cluster-management-policies
+          rules:
+            - apiGroups: ["policy.open-cluster-management.io"]
+              resources: ["operatorpolicies"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: operatorpolicy-manager-binding
+            namespace: open-cluster-management-policies
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: operatorpolicy-manager
+          subjects:
+            - kind: ServiceAccount
+              name: klusterlet-work-sa
+              namespace: open-cluster-management-agent
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: OperatorPolicy
+          metadata:
+            name: kubevirt-hyperconverged-operator
+            namespace: open-cluster-management-policies
+          spec:
+            remediationAction: enforce
+            complianceType: musthave
+            operatorGroup: # optional
+              name: openshift-cnv
+              namespace: openshift-cnv
+              targetNamespaces:
+                  - openshift-cnv
+            subscription:
+              channel: stable
+              name: kubevirt-hyperconverged
+              namespace: openshift-cnv
+            upgradeApproval: Automatic
+        - apiVersion: hco.kubevirt.io/v1beta1
+          kind: HyperConverged
+          metadata:
+            name: kubevirt-hyperconverged
+            annotations:
+              deployOVS: 'false'
+            namespace: openshift-cnv
+          spec:
+            virtualMachineOptions:
+              disableFreePageReporting: false
+              disableSerialConsoleLog: true
+            higherWorkloadDensity:
+              memoryOvercommitPercentage: 100
+            liveMigrationConfig:
+              allowAutoConverge: false
+              allowPostCopy: false
+              completionTimeoutPerGiB: 800
+              parallelMigrationsPerCluster: 5
+              parallelOutboundMigrationsPerNode: 2
+              progressTimeout: 150
+            certConfig:
+              ca:
+                duration: 48h0m0s
+                renewBefore: 24h0m0s
+              server:
+                duration: 24h0m0s
+                renewBefore: 12h0m0s
+            applicationAwareConfig:
+              allowApplicationAwareClusterResourceQuota: false
+              vmiCalcConfigName: DedicatedVirtualResources
+            featureGates:
+              deployTektonTaskResources: false
+              enableCommonBootImageImport: true
+              withHostPassthroughCPU: false
+              downwardMetrics: false
+              disableMDevConfiguration: false
+              enableApplicationAwareQuota: false
+              deployKubeSecondaryDNS: false
+              nonRoot: true
+              alignCPUs: false
+              enableManagedTenantQuota: false
+              primaryUserDefinedNetworkBinding: false
+              deployVmConsoleProxy: false
+              persistentReservation: false
+              autoResourceLimits: false
+              deployKubevirtIpamController: false
+            workloadUpdateStrategy:
+              batchEvictionInterval: 1m0s
+              batchEvictionSize: 10
+              workloadUpdateMethods:
+                - LiveMigrate
+            uninstallStrategy: BlockUninstallIfWorkloadsExist
+            resourceRequirements:
+              vmiCPUAllocationRatio: 10

--- a/charts/templates/cnv-clustermanagementaddon.yaml
+++ b/charts/templates/cnv-clustermanagementaddon.yaml
@@ -1,0 +1,20 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: kubevirt-hyperconverged-operator
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: Kubevirt Hyperconverged Operator
+    displayName: Kubevirt Hyperconverged Operator
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: kubevirt-hyperconverged-operator
+  installStrategy:
+    type: Placements
+    placements:
+    - name: openshift-cnv
+      namespace: open-cluster-management

--- a/charts/templates/cnv-global-placement.yaml
+++ b/charts/templates/cnv-global-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: openshift-cnv
+  namespace: {{ .Values.global.namespace }}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            acm/cnv-operator-install: "true"

--- a/charts/templates/global-clusterset-binding.yaml
+++ b/charts/templates/global-clusterset-binding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: {{ .Values.global.namespace }}
+spec:
+  clusterSet: global

--- a/charts/templates/mtv-addon-template.yaml
+++ b/charts/templates/mtv-addon-template.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: mtv-operator
+spec:
+  addonName: mtv-operator
+  registration:
+    - type: CustomSigner
+      customSigner:
+        signerName: open-cluster-management.io/kubevirt-hyperconverged-addon
+        signingCA:
+          name: mtv-operator-ca
+          namespace: openshift-mtv
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: OperatorPolicy
+          metadata:
+            name: mtv-operator
+            namespace: open-cluster-management-policies
+          spec:
+            complianceType: musthave
+            remediationAction: enforce
+            subscription:
+              channel: release-v2.8
+              name: mtv-operator
+              namespace: openshift-mtv
+            upgradeApproval: Automatic
+        - apiVersion: forklift.konveyor.io/v1beta1
+          kind: ForkliftController
+          metadata:
+            name: forklift-controller
+            namespace: openshift-mtv
+          spec:
+            feature_ui_plugin: 'true'
+            feature_validation: 'true'
+            feature_volume_populator: 'true'
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: mtv-integrations-controller
+            namespace: {{ .Values.global.namespace }}
+            labels:
+              app: mtv-integrations
+              ocm-antiaffinity-selector: "mtvintegrations"
+              chart: mtv-integrations-{{ .Values.hubconfig.hubVersion }}
+              app.kubernetes.io/name: mtv-integrations
+              app.kubernetes.io/instance: mtv-integrations
+              component: "ocm-mtv-integrations-ctrl"
+              release: mtv-integrations
+          spec:
+            selector:
+              matchLabels:
+                app: mtv-integrations
+                component: "ocm-mtv-integrations-ctrl"
+                release: mtv-integrations
+            replicas: {{ .Values.hubconfig.replicaCount }}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: controller
+                labels:
+                  control-plane: mtv-controller
+                  app.kubernetes.io/name: mtv-integrations
+              spec:
+                serviceAccountName: mtv-integrations-manager
+                hostNetwork: false
+                hostPID: false
+                hostIPC: false
+                securityContext:
+                  runAsNonRoot: true
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                                - arm64
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - weight: 70
+                        podAffinityTerm:
+                          topologyKey: topology.kubernetes.io/zone
+                          labelSelector:
+                            matchExpressions:
+                              - key: ocm-antiaffinity-selector
+                                operator: In
+                                values:
+                                  - mtvintegrations
+                      - weight: 35
+                        podAffinityTerm:
+                          topologyKey: kubernetes.io/hostname
+                          labelSelector:
+                            matchExpressions:
+                              - key: ocm-antiaffinity-selector
+                                operator: In
+                                values:
+                                  - mtvintegrations
+                {{- with .Values.hubconfig.tolerations }}
+                tolerations:
+                {{- range . }}
+                - {{ if .Key }} key: {{ .Key }} {{- end }}
+                  {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+                  {{ if .Value }} value: {{ .Value }} {{- end }}
+                  {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+                  {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+                  {{- end }}
+                {{- end }}
+                containers:
+                  - name: mtv-integrations-controller
+                    command:
+                      - /manager
+                    args:
+                      - --health-probe-bind-address=:8081
+                    image: {{ .Values.global.imageOverrides.mtv_integrations_controller }}
+                    imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+                    ports:
+                      - containerPort: 9443
+                        protocol: TCP
+                        name: webhook-http
+                    securityContext:
+                      privileged: false
+                      readOnlyRootFilesystem: true
+                      allowPrivilegeEscalation: false
+                      runAsNonRoot: true
+                      capabilities:
+                        drop:
+                          - ALL
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
+                volumes:
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: mtv-plan-webhook-server-cert
+                {{- if .Values.global.pullSecret }}
+                imagePullSecrets:
+                  - name: {{ .Values.global.pullSecret }}
+                {{- end }}
+                {{- with .Values.hubconfig.nodeSelector }}
+                nodeSelector:
+                {{- toYaml . | nindent 18 }}
+                {{- end }}

--- a/charts/templates/mtv-clustermanagementaddon.yaml
+++ b/charts/templates/mtv-clustermanagementaddon.yaml
@@ -1,0 +1,20 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: mtv-operator
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: MTV Operator
+    displayName: MTV Operator
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: mtv-operator
+  installStrategy:
+    type: Placements
+    placements:
+    - name: openshift-mtv
+      namespace: open-cluster-management

--- a/charts/templates/mtv-global-placement.yaml
+++ b/charts/templates/mtv-global-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: openshift-mtv
+  namespace: {{ .Values.global.namespace }}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            local-cluster: "true"

--- a/charts/templates/mtv-integration-webhook-service.yaml
+++ b/charts/templates/mtv-integration-webhook-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: mtv-plan-webhook-server-cert
+  name: mtv-plan-webhook-service
+  namespace: {{ .Values.global.namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: mtv-integrations

--- a/charts/templates/mtv-integrations-clusterrole.yaml
+++ b/charts/templates/mtv-integrations-clusterrole.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager-role
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - authentication.open-cluster-management.io
+  resources:
+  - managedserviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.open-cluster-management.io
+  resources:
+  - clusterpermissions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - providers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/templates/mtv-integrations-clusterrolebinding.yaml
+++ b/charts/templates/mtv-integrations-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mtv-integrations-manager-role
+subjects:
+- kind: ServiceAccount
+  name: mtv-integrations-manager
+  namespace: {{ .Values.global.namespace }}

--- a/charts/templates/mtv-integrations-sa.yaml
+++ b/charts/templates/mtv-integrations-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager
+  namespace: {{ .Values.global.namespace }}

--- a/charts/templates/mtv-integrations-validating-config.yaml
+++ b/charts/templates/mtv-integrations-validating-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: mtv-plan-webhook-validating-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: mtv-plan-webhook-service
+      namespace: {{ .Values.global.namespace }}
+      path: /validate-plan
+  failurePolicy: Fail
+  name: validate.mtv.plan
+  rules:
+  - apiGroups:
+    - forklift.konveyor.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - plans
+  sideEffects: None

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Red Hat, Inc.
+global:
+  imageOverrides:
+    mtv_integrations_controller: ""
+  templateOverrides: {}
+  namespace: default
+  pullSecret: null
+  pullPolicy: Always
+  hubSize: Small
+hubconfig:
+  nodeSelector: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+  ocpVersion: 4.18.0
+org: open-cluster-management


### PR DESCRIPTION
Description
This commit adds the necessary resources for the chart automation process used by the Multicluster Hub Operator.

Related issue: [ACM-21706](https://issues.redhat.com/browse/ACM-21706)

Requested via Slack: [Internal discussion](https://redhat-internal.slack.com/archives/C094HCLRXEK/p1752599668503169)

Meeting notes: [Google Doc](https://docs.google.com/document/d/1g-uK-VMU3jiQQomrt9UaZFH3oqXJ85DrVdL9JbnCD3A/edit?tab=t.k1okkzoayn7p)

These resources enable streamlined automation for managing the Multicluster Hub Operator charts.