### PR TITLE
This will cause the gemini-pr-review to occur when an update to the P…

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -5,6 +5,7 @@ on:
     types:
       - 'opened'
       - 'reopened'
+      - 'synchronize'
   issue_comment:
     types:
       - 'created'


### PR DESCRIPTION
…R is made with additional commits. Today the review only happens once when the PR is initiated.