### PR TITLE
possible fix for mintmaker issue with parentheses

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "groupName": "containerfile images ({{{baseBranch}}})",
+      "groupName": "containerfile images [{{{baseBranch}}}]",
       "matchManagers": ["dockerfile"]
     }
   ]


### PR DESCRIPTION
Trying to fix the issue seen here:
https://github.com/stolostron/mtv-integrations/pull/116

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stolostron_mtv-integrations/116/pull-ci-stolostron-mtv-integrations-main-sonar/1961095798171111424

It seems the shell is interpreting the parentheses as a subshell. Replacing them with square brackets or removing them should resolve the issue.