### PR TITLE
enable Slack notifications on push failures

### DIFF
--- a/.tekton/mtv-integrations-acm-215-push.yaml
+++ b/.tekton/mtv-integrations-acm-215-push.yaml
@@ -40,6 +40,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: send-slack-notification
+    value: true
+  - name: konflux-application-name
+    value: release-acm-215 # Need to be updated for each release
+  - name: slack-member-id
+    value: U011N5GTVPG # @Sahar, The slack member id of the current component owner.
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Note: The notification feature currently only supports mentioning individual users (via Slack member IDs) — @group mentions aren’t supported.
Notifications are posted to #forum-acm-konflux-pipeline-status, using the default Slack webhook secret name and key.
