### PR TITLE
Add network placeholder in addontemplate

### DIFF
--- a/addons/cnv-addon/addondeploymentconfig.yaml
+++ b/addons/cnv-addon/addondeploymentconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: cnv-config
+  namespace: open-cluster-management
+spec:
+  agentInstallNamespace: openshift-cnv
+  customizedVariables:
+  - name: LIVE_NETWORK_KEY
+  - name: LIVE_NETWORK_VALUE  

--- a/addons/cnv-addon/global-placement.yaml
+++ b/addons/cnv-addon/global-placement.yaml
@@ -9,4 +9,7 @@ spec:
         labelSelector:
           matchLabels:
             acm/cnv-operator-install: "true"
-
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            local-cluster: "true"

--- a/addons/cnv-addon/kubevirt-hyperconverged-addon-template.yaml
+++ b/addons/cnv-addon/kubevirt-hyperconverged-addon-template.yaml
@@ -95,6 +95,7 @@ spec:
               parallelMigrationsPerCluster: 5
               parallelOutboundMigrationsPerNode: 2
               progressTimeout: 150
+              "{{LIVE_NETWORK_KEY}}": "{{LIVE_NETWORK_VALUE}}"
             certConfig:
               ca:
                 duration: 48h0m0s

--- a/addons/cnv-addon/kubevirt-hyperconverged-addon.yaml
+++ b/addons/cnv-addon/kubevirt-hyperconverged-addon.yaml
@@ -13,6 +13,11 @@ spec:
       resource: addontemplates
       defaultConfig:
         name: kubevirt-hyperconverged-operator
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs
+      defaultConfig:
+        name: cnv-config
+        namespace: open-cluster-management
   installStrategy:
     type: Placements
     placements:

--- a/charts/templates/cnv-addon-template.yaml
+++ b/charts/templates/cnv-addon-template.yaml
@@ -100,6 +100,7 @@ spec:
               parallelMigrationsPerCluster: 5
               parallelOutboundMigrationsPerNode: 2
               progressTimeout: 150
+              "{{ `{{LIVE_NETWORK_KEY}}` }}":  "{{ `{{LIVE_NETWORK_VALUE}}` }}"
             certConfig:
               ca:
                 duration: 48h0m0s

--- a/charts/templates/cnv-addondeploymentconfig.yaml
+++ b/charts/templates/cnv-addondeploymentconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: cnv-config
+  namespace: {{ .Values.global.namespace }}
+spec:
+  agentInstallNamespace: openshift-cnv
+  customizedVariables:
+  - name: LIVE_NETWORK_KEY
+  - name: LIVE_NETWORK_VALUE  

--- a/charts/templates/cnv-clustermanagementaddon.yaml
+++ b/charts/templates/cnv-clustermanagementaddon.yaml
@@ -13,6 +13,11 @@ spec:
       resource: addontemplates
       defaultConfig:
         name: kubevirt-hyperconverged-operator
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs
+      defaultConfig:
+        name: cnv-config
+        namespace: {{ .Values.global.namespace }}
   installStrategy:
     type: Placements
     placements:


### PR DESCRIPTION
**Description**: 
Templatize the network field in the HyperConverged resource within the CNV AddOnTemplate, so that users can configure their own network through the ManagedClusterAddOn and an AddOnDeploymentConfig.
