### PR TITLE
webhook: allow kubevirt.io:edit UserPermission for Plan validation

### DIFF
--- a/webhook/plan_webhook.go
+++ b/webhook/plan_webhook.go
@@ -25,6 +25,8 @@ import (
 const (
 	userPermissionManagedClusterAdmin = "managedcluster:admin"
 	userPermissionKubevirtAdmin       = "kubevirt.io:admin"
+	userPermissionKubevirtEdit        = "kubevirt.io:edit"
+
 	// envUserPermissionNames is optional (e2e/kind): comma-separated UserPermission resource names to GET.
 	// Standard Kubernetes rejects ':' in metadata.name,
 	// so local e2e uses DNS-safe names via this env; production leaves it unset.
@@ -109,7 +111,7 @@ func rawToPlan(rawExt runtime.RawExtension) (*v1beta1.Plan, error) {
 }
 
 // validateTargetAccessViaUserPermissions allows the Plan if any configured UserPermission
-// (default: managedcluster:admin, kubevirt.io:admin; see MTV_USERPERMISSION_NAMES) has a status
+// (default: managedcluster:admin, kubevirt.io:admin, kubevirt.io:edit; see MTV_USERPERMISSION_NAMES) has a status
 // binding for the target cluster and namespace (namespaces list may contain '*' for all namespaces).
 func validateTargetAccessViaUserPermissions(
 	ctx context.Context,
@@ -142,7 +144,11 @@ func userPermissionLookupNames() []string {
 			return out
 		}
 	}
-	return []string{userPermissionManagedClusterAdmin, userPermissionKubevirtAdmin}
+	return []string{
+		userPermissionManagedClusterAdmin,
+		userPermissionKubevirtAdmin,
+		userPermissionKubevirtEdit,
+	}
 }
 
 func userPermissionCoversTarget(

--- a/webhook/plan_webhook_test.go
+++ b/webhook/plan_webhook_test.go
@@ -202,6 +202,17 @@ func TestValidateTargetAccessViaUserPermissions(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})
+
+	t.Run("allow when only kubevirt edit matches", func(t *testing.T) {
+		t.Parallel()
+		edit := userPermissionObject(userPermissionKubevirtEdit, []map[string]interface{}{
+			{"cluster": "target", "namespaces": []interface{}{"ns1"}},
+		})
+		client := fake.NewSimpleDynamicClient(scheme, edit)
+		ok, err := validateTargetAccessViaUserPermissions(context.Background(), client, "target", "ns1")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
 }
 
 func TestValidateTargetAccessViaUserPermissions_EnvLookupNames(t *testing.T) {


### PR DESCRIPTION
webhook: allow kubevirt.io:edit UserPermission for Plan validation

- Include kubevirt.io:edit in the default UserPermission lookup 
- Add a test for edit-only bindings. Ref: https://redhat.atlassian.net/browse/ACM-28875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new edit-level permission for kubevirt users, enabling more granular permission management and access control for cluster operations.
  * Updated default permission validation logic to recognize the new edit permission alongside existing admin-level permissions automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->