### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY go.sum go.sum
 
 # Cache deps
 # RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go mod vendor
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} go mod tidy
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOFLAGS='-mod=readonly' go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
@@ -21,7 +21,7 @@ COPY webhook/ webhook/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} go build -a -mod=mod -o manager cmd/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOFLAGS='-mod=readonly' go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY webhook/ webhook/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} go build -a -mod=mod -o manager cmd/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} go build -a -mod=mod -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -10,7 +10,7 @@ COPY go.sum go.sum
 
 # Cache deps
 # RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go mod vendor
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} go mod tidy
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOFLAGS='-mod=readonly' go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
@@ -21,7 +21,7 @@ COPY webhook/ webhook/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} go build -a -mod=mod -o manager cmd/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOFLAGS='-mod=readonly' go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847