### PR TITLE
chore(addon): bump mtv-operator to 2.12 and keep OperatorPolicy creat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository also contains two addons for OCM that enable container native vi
 
 **Quick summary:**
 
-- **MTV Addon:** Installs the Migration Toolkit for Virtualization operator in the `openshift-mtv` namespace on the hub, enabling VM migration features. It uses the `release-v2.11` channel and enables UI plugin, validation, and volume populator features.
+- **MTV Addon:** Installs the Migration Toolkit for Virtualization operator in the `openshift-mtv` namespace on the hub, enabling VM migration features. It uses the `release-v2.12` channel and enables UI plugin, validation, and volume populator features.
 - **CNV Addon:** Installs the KubeVirt Hyperconverged operator in the `openshift-cnv` namespace, providing virtualization capabilities. It configures optimized HyperConverged settings and uses OperatorPolicy for lifecycle management.
 
 Both addons require ACM and the Policy addon. The CNV Addon targets clusters labeled with `acm/cnv-operator-install: "true"`.

--- a/addons/README.md
+++ b/addons/README.md
@@ -26,7 +26,7 @@ The MTV Addon deploys the Migration Toolkit for Virtualization operator, which e
 
 ### Configuration
 The addon is configured to:
-- Use the `release-v2.11` channel for operator updates
+- Use the `release-v2.12` channel for operator updates
 - Deploy in the `openshift-mtv` namespace
 - Enable UI plugin, validation, and volume populator features
 

--- a/addons/cnv-addon/cnv-addon-template.yaml
+++ b/addons/cnv-addon/cnv-addon-template.yaml
@@ -20,6 +20,13 @@ spec:
           namespace: openshift-cnv
         updateStrategy:
           type: CreateOnly
+      - resourceIdentifier:
+          group: policy.open-cluster-management.io
+          resource: operatorpolicies
+          name: kubevirt-hyperconverged-operator
+          namespace: open-cluster-management-policies
+        updateStrategy:
+          type: CreateOnly
     workload:
       manifests:
         - apiVersion: hco.kubevirt.io/v1beta1

--- a/addons/mtv-addon/mtv-addon-template.yaml
+++ b/addons/mtv-addon/mtv-addon-template.yaml
@@ -12,6 +12,14 @@ spec:
           name: mtv-operator-ca
           namespace: openshift-mtv
   agentSpec:
+    manifestConfigs:
+      - resourceIdentifier:
+          group: policy.open-cluster-management.io
+          resource: operatorpolicies
+          name: mtv-operator
+          namespace: open-cluster-management-policies
+        updateStrategy:
+          type: CreateOnly
     workload:
       manifests:
         - apiVersion: policy.open-cluster-management.io/v1beta1
@@ -28,7 +36,7 @@ spec:
               targetNamespaces:
                   - openshift-mtv
             subscription:
-              channel: release-v2.11
+              channel: release-v2.12
               name: mtv-operator
               namespace: openshift-mtv
             upgradeApproval: Automatic

--- a/charts/templates/cnv-addon-template.yaml
+++ b/charts/templates/cnv-addon-template.yaml
@@ -20,6 +20,13 @@ spec:
           namespace: openshift-cnv
         updateStrategy:
           type: CreateOnly
+      - resourceIdentifier:
+          group: policy.open-cluster-management.io
+          resource: operatorpolicies
+          name: kubevirt-hyperconverged-operator
+          namespace: open-cluster-management-policies
+        updateStrategy:
+          type: CreateOnly
     workload:
       manifests:
         - apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/templates/mtv-addon-template.yaml
+++ b/charts/templates/mtv-addon-template.yaml
@@ -6,6 +6,14 @@ metadata:
 spec:
   addonName: mtv-operator
   agentSpec:
+    manifestConfigs:
+      - resourceIdentifier:
+          group: policy.open-cluster-management.io
+          resource: operatorpolicies
+          name: mtv-operator
+          namespace: open-cluster-management-policies
+        updateStrategy:
+          type: CreateOnly
     workload:
       manifests:
         - apiVersion: policy.open-cluster-management.io/v1beta1
@@ -22,11 +30,9 @@ spec:
               targetNamespaces:
                   - openshift-mtv
             subscription:
-              channel: dev-preview
+              channel: release-v2.12
               name: mtv-operator
               namespace: openshift-mtv
-              source: mtv-extra-catalog-source
-              sourceNamespace: openshift-marketplace
             upgradeApproval: Automatic
         - apiVersion: forklift.konveyor.io/v1beta1
           kind: ForkliftController


### PR DESCRIPTION
Updates the MTV operator subscription channel to release-v2.12 and adds manifestConfigs.updateStrategy.type: CreateOnly so user changes to the mtv-operator OperatorPolicy are preserved instead of being overwritten by addon reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Moved MTV addon operator to the release-v2.12 channel for updated operator delivery.
  * Registered the operator policy manifest to ensure policy resources are created and managed with a create-only update strategy.
  * Removed deprecated subscription source and namespace fields for cleaner operator subscription configuration.

* **Documentation**
  * Updated addon README and docs to reflect the new release channel and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->