### PR TITLE
Add Renovate schema for MintMaker PR automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,53 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "addLabels": [
-    "ok-to-test"
-  ],
-  "baseBranchPatterns": [
-    "main",
-    "release-2.15"
-  ],
-  "prConcurrentLimit": 0,
-  "dependencyDashboard": true,
   "timezone": "America/New_York",
-  "dockerfile": {
-    "managerFilePatterns": [
-      "Dockerfile.rhtap"
-    ],
-    "ignorePaths": [
-      "**/Dockerfile"
-    ],
-    "pinDigests": false
-  },
-  "gomod": {
-    "packageRules": [
-      {
-        "matchDepTypes": [
-          "indirect"
-        ],
-        "enabled": false
-      },
-      {
-        "matchBaseBranches": [
-          "release-2.15"
-        ],
-        "matchManagers": [
-          "gomod"
-        ],
-        "enabled": false
-      }
-    ]
-  },
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  "osvVulnerabilityAlerts": true,
-  "packageRules": [
-    {
-      "groupName": "containerfile images [{{{baseBranch}}}]",
-      "matchManagers": [
-        "dockerfile"
-      ]
-    }
+  "extends": [
+    "github>stolostron/governance-policy-framework//.github/renovate_default"
   ]
 }


### PR DESCRIPTION
## Summary
- Replace repo-specific Renovate settings with the shared default config from `stolostron/governance-policy-framework`.
- Keep Renovate timezone set to `America/New_York`.
- Track Jira: https://redhat.atlassian.net/browse/ACM-34040

## Test plan
- [x] Confirm `.github/renovate.json` is valid JSON.
- [x] Verify config contains the expected schema, timezone, and extends entry.
- [ ] Optional: run Renovate dry-run in CI context.

Made with [Cursor](https://cursor.com)