### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -1,0 +1,6 @@
+---
+description: System architecture reference for mtv-integrations
+alwaysApply: false
+---
+
+@docs/ARCHITECTURE.md

--- a/.cursor/rules/fleet-skills.mdc
+++ b/.cursor/rules/fleet-skills.mdc
@@ -1,0 +1,37 @@
+---
+description: Fleet Engineering Agentic SDLC — skills reference for Cursor
+alwaysApply: false
+---
+
+# Fleet Engineering Skills
+
+Fetch and apply the relevant skill from the [agentic-sdlc repo](https://github.com/OpenShift-Fleet/agentic-sdlc) when the task matches its domain.
+
+## Jira skills (`skills/jira/`)
+
+- **jira-create** — Interactive issue creation with specialist delegation
+- **jira-specialist** — General triage, search, linking, transitions
+- **bug-specialist** — Bug triage, reproduction steps, fix planning
+- **story-specialist** — User stories with acceptance criteria
+- **task-specialist** — Internal technical tasks
+- **epic-specialist** — Multi-sprint epics with outcomes
+- **feature-specialist** — Large customer-facing capabilities
+- **initiative-specialist** — Multi-team strategic programs
+- **outcome-specialist** — Strategic outcomes tied to OKRs
+- **spike-specialist** — Time-boxed research and PoC
+
+## SDLC skills (`skills/sdlc/`)
+
+- **start-work** — Create a Jira sub-task to begin work
+- **finish-work** — Commit, push, open PR, update Jira
+- **pr-review** — GitHub PR review with worktree isolation and inline comments
+- **pr-fix** — Fix blocked PRs: merge conflicts, CI failures, review comments
+- **agent-memory-setup** — Initialize or update CLAUDE.md / AGENTS.md for a repo
+- **repo-content-audit** — Scan for unlinked or orphaned content
+- **opencode-setup** — Install and configure OpenCode
+
+## Meeting skills (`skills/meetings/`)
+
+- **f2f-daily-summary** — Capture daily F2F meeting notes as Jira sub-tasks
+- **f2f-epic-specialist** — Create and manage F2F meeting Epics
+- **presentation-task** — Log a delivered presentation as a closed Jira sub-task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+MTV Integrations is a Go controller-runtime operator that integrates the Migration Toolkit for Virtualization (MTV/Forklift) with Advanced Cluster Management (ACM). It has three runtime components:
+
+1. **ManagedCluster Reconciler** — watches ManagedCluster resources labeled `mtv.konveyor.io/provider: "true"` and creates the ManagedServiceAccount, ClusterPermission, provider Secret, and Forklift Provider CR needed to onboard each cluster as an MTV provider.
+2. **Plan Validation Webhook** — a validating admission webhook at `/validate-plan` (port 9443) that impersonates the requesting user and checks `UserPermission` resources (`managedcluster:admin` / `kubevirt.io:admin`) to authorize Plan CREATE/UPDATE.
+3. **Migration Advisor API** — a plain-HTTP server (default `:8082`) at `/api/v1/migration-targets` that scores candidate clusters for a given source VM using Thanos metrics and the ACM Search API.
+
+The repo also ships OCM addon manifests under `addons/` (CNV addon and MTV addon) — these are pure YAML, not Go code.
+
+## Build and test commands
+
+```bash
+make build                # fmt + vet + compile bin/manager
+make test                 # unit tests (envtest, excludes e2e); installs tools on first run
+make lint                 # golangci-lint (config: .golangci.yml)
+make lint-fix             # lint with auto-fix
+```
+
+### Running a single test
+
+```bash
+# Single package
+go test -v ./controllers/migrationadvisor/...
+
+# Single test by name (regex)
+go test -v ./webhook/... -run TestValidateWebhook
+```
+
+### E2E tests (require kind cluster)
+
+E2E tests use Ginkgo with label filters. Each suite needs a kind cluster set up first:
+
+```bash
+make prepare-e2e-test              # kind + cert-manager + CRDs + deploy controller
+make run-e2e-test                  # core e2e (excludes webhook, provider-crd, advisor)
+make run-webhook-test              # webhook e2e (needs prepare-webhook-test instead)
+make run-provider-crd-test         # provider CRD e2e
+make run-advisor-test              # migration advisor e2e (starts fake Thanos + Search servers)
+make delete-cluster                # tear down kind
+```
+
+### Running locally (no webhook)
+
+```bash
+make run                           # or use VS Code launch config with --enable-webhook=false
+```
+
+## Architecture
+
+For detailed architecture, see [architecture/README.md](architecture/README.md).
+
+### Key source layout
+
+- `cmd/main.go` — entrypoint; wires up the manager, webhook server, and advisor HTTP server; auto-discovers ACM Search and Thanos Route URLs at startup.
+- `controllers/managedcluster_controller.go` — the `ManagedClusterReconciler`; manages Provider lifecycle via dynamic client and unstructured objects (no generated CRD types for Provider).
+- `controllers/payloads.go` — GVR constants and payload constructors for Provider, ClusterPermission, ManagedServiceAccount, and Secret resources.
+- `controllers/migrationadvisor/` — migration advisor: `handler.go` (HTTP handler + cluster data cache), `scorer.go` (scoring algorithm), `vm_fetcher.go` (VM lookup via Search API), `observability_client.go` (Thanos queries), `search_client.go` (ACM Search GraphQL).
+- `webhook/plan_webhook.go` — admission handler; checks `UserPermission` resources to authorize Plan operations.
+- `api/types.go` — shared request/response types for the migration advisor API.
+- `addons/` — OCM AddOnTemplate YAML for CNV and MTV operators (not Go code).
+
+### Design patterns
+
+- **No generated CRD types for Provider**: the controller uses `dynamic.Interface` with `unstructured.Unstructured` objects and hand-built payloads (`payloads.go`) instead of generated typed clients.
+- **Finalizer-based cleanup**: `ManagedClusterFinalizer` on ManagedCluster resources ensures Provider, Secret, ClusterPermission, and ManagedServiceAccount are cleaned up on deletion or label removal.
+- **Resources follow a naming convention**: managed resources are named `<cluster-name>-mtv` (e.g., provider, secret, service account).
+- **UserPermission names are configurable**: the webhook reads `MTV_USERPERMISSION_NAMES` env var for e2e/kind testing because standard Kubernetes rejects `:` in resource names.
+- **Advisor caching**: cluster-wide data (node metrics, Ceph metrics, StorageClasses) is cached with a configurable TTL (default 30s) and uses `singleflight` to deduplicate concurrent cache rebuilds.
+
+## Testing patterns
+
+- Unit tests use controller-runtime's `envtest` (real etcd + API server, no mocking).
+- E2E tests use Ginkgo/Gomega with label filters (`webhook`, `managedcluster_provider_crd`, `migration_advisor`).
+- Advisor e2e tests start fake Thanos and Search servers (`test/utils/fake-thanos-server/`, `test/utils/fake-search-server/`).
+- Test helpers are in `test/utils/`.
+
+## CI
+
+GitHub Actions runs unit tests, webhook tests, provider-CRD tests, e2e tests, and advisor tests as separate jobs, then aggregates coverage for SonarCloud.
+
+## Personal configuration
+
+Read personal config at the start of any task that needs an assignee, email, or project key.
+Use the tool-aware fallback chain: ~/.config/opencode/user.local.md (OpenCode),
+.claude/user.local.md (Claude Code), or .cursor/rules/user.local.mdc (Cursor, already in context).
+If none exist, fall back to agent memory (`user-config`), then placeholders.
+Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
+
+## Fleet Engineering Skills
+
+Fetch and apply the relevant skill when the task matches its domain.
+
+| Skill | When to use |
+|---|---|
+| [jira-create](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-create/SKILL.md) | Interactive issue creation with specialist delegation |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | General triage, search, linking, transitions |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Bug triage, reproduction steps, fix planning |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | User stories with acceptance criteria |
+| [task-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/task-specialist/SKILL.md) | Internal technical tasks |
+| [epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/epic-specialist/SKILL.md) | Multi-sprint epics with outcomes |
+| [feature-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/feature-specialist/SKILL.md) | Large customer-facing capabilities |
+| [initiative-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/initiative-specialist/SKILL.md) | Multi-team strategic programs |
+| [outcome-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/outcome-specialist/SKILL.md) | Strategic outcomes tied to OKRs |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC |
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Create a Jira sub-task to begin work |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | GitHub PR review with worktree isolation and inline comments |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [agent-memory-setup](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/agent-memory-setup/SKILL.md) | Initialize or update CLAUDE.md / AGENTS.md for a repo |
+| [repo-content-audit](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/repo-content-audit/SKILL.md) | Scan for unlinked or orphaned content |
+| [opencode-setup](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/opencode-setup/SKILL.md) | Install and configure OpenCode |
+| [f2f-daily-summary](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-daily-summary/SKILL.md) | Capture daily F2F meeting notes as Jira sub-tasks |
+| [f2f-epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-epic-specialist/SKILL.md) | Create and manage F2F meeting Epics |
+| [presentation-task](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/presentation-task/SKILL.md) | Log a delivered presentation as a closed Jira sub-task |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,27 +93,4 @@ Run `make personalize` to generate all three files (if this repo uses Fleet Engi
 
 ## Fleet Engineering Skills
 
-Fetch and apply the relevant skill when the task matches its domain.
-
-| Skill | When to use |
-|---|---|
-| [jira-create](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-create/SKILL.md) | Interactive issue creation with specialist delegation |
-| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | General triage, search, linking, transitions |
-| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Bug triage, reproduction steps, fix planning |
-| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | User stories with acceptance criteria |
-| [task-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/task-specialist/SKILL.md) | Internal technical tasks |
-| [epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/epic-specialist/SKILL.md) | Multi-sprint epics with outcomes |
-| [feature-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/feature-specialist/SKILL.md) | Large customer-facing capabilities |
-| [initiative-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/initiative-specialist/SKILL.md) | Multi-team strategic programs |
-| [outcome-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/outcome-specialist/SKILL.md) | Strategic outcomes tied to OKRs |
-| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC |
-| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Create a Jira sub-task to begin work |
-| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
-| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | GitHub PR review with worktree isolation and inline comments |
-| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
-| [agent-memory-setup](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/agent-memory-setup/SKILL.md) | Initialize or update CLAUDE.md / AGENTS.md for a repo |
-| [repo-content-audit](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/repo-content-audit/SKILL.md) | Scan for unlinked or orphaned content |
-| [opencode-setup](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/opencode-setup/SKILL.md) | Install and configure OpenCode |
-| [f2f-daily-summary](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-daily-summary/SKILL.md) | Capture daily F2F meeting notes as Jira sub-tasks |
-| [f2f-epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-epic-specialist/SKILL.md) | Create and manage F2F meeting Epics |
-| [presentation-task](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/presentation-task/SKILL.md) | Log a delivered presentation as a closed Jira sub-task |
+All skills are available as slash commands via the installed Fleet Engineering plugin. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,25 +52,7 @@ make run                           # or use VS Code launch config with --enable-
 
 ## Architecture
 
-For detailed architecture, see [architecture/README.md](architecture/README.md).
-
-### Key source layout
-
-- `cmd/main.go` — entrypoint; wires up the manager, webhook server, and advisor HTTP server; auto-discovers ACM Search and Thanos Route URLs at startup.
-- `controllers/managedcluster_controller.go` — the `ManagedClusterReconciler`; manages Provider lifecycle via dynamic client and unstructured objects (no generated CRD types for Provider).
-- `controllers/payloads.go` — GVR constants and payload constructors for Provider, ClusterPermission, ManagedServiceAccount, and Secret resources.
-- `controllers/migrationadvisor/` — migration advisor: `handler.go` (HTTP handler + cluster data cache), `scorer.go` (scoring algorithm), `vm_fetcher.go` (VM lookup via Search API), `observability_client.go` (Thanos queries), `search_client.go` (ACM Search GraphQL).
-- `webhook/plan_webhook.go` — admission handler; checks `UserPermission` resources to authorize Plan operations.
-- `api/types.go` — shared request/response types for the migration advisor API.
-- `addons/` — OCM AddOnTemplate YAML for CNV and MTV operators (not Go code).
-
-### Design patterns
-
-- **No generated CRD types for Provider**: the controller uses `dynamic.Interface` with `unstructured.Unstructured` objects and hand-built payloads (`payloads.go`) instead of generated typed clients.
-- **Finalizer-based cleanup**: `ManagedClusterFinalizer` on ManagedCluster resources ensures Provider, Secret, ClusterPermission, and ManagedServiceAccount are cleaned up on deletion or label removal.
-- **Resources follow a naming convention**: managed resources are named `<cluster-name>-mtv` (e.g., provider, secret, service account).
-- **UserPermission names are configurable**: the webhook reads `MTV_USERPERMISSION_NAMES` env var for e2e/kind testing because standard Kubernetes rejects `:` in resource names.
-- **Advisor caching**: cluster-wide data (node metrics, Ceph metrics, StorageClasses) is cached with a configurable TTL (default 30s) and uses `singleflight` to deduplicate concurrent cache rebuilds.
+For system design, data flows, and module layout, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). Also see [architecture/README.md](architecture/README.md) for the original controller/webhook summary.
 
 ## Testing patterns
 
@@ -82,6 +64,11 @@ For detailed architecture, see [architecture/README.md](architecture/README.md).
 ## CI
 
 GitHub Actions runs unit tests, webhook tests, provider-CRD tests, e2e tests, and advisor tests as separate jobs, then aggregates coverage for SonarCloud.
+
+## Tool availability
+
+- `gh` CLI is installed — use it for GitHub operations.
+- `jira` CLI is installed — but prefer MCP tools (`mcp__jira-mcp-server__*`) for Jira operations when available.
 
 ## Personal configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-MTV Integrations is a Go controller-runtime operator that integrates the Migration Toolkit for Virtualization (MTV/Forklift) with Advanced Cluster Management (ACM). It has three runtime components:
+MTV Integrations is a Go controller-runtime operator that integrates the Migration Toolkit for Virtualization (MTV/Forklift) with Advanced Cluster Management (ACM). It has four runtime components:
 
-1. **ManagedCluster Reconciler** — watches ManagedCluster resources labeled `mtv.konveyor.io/provider: "true"` and creates the ManagedServiceAccount, ClusterPermission, provider Secret, and Forklift Provider CR needed to onboard each cluster as an MTV provider.
-2. **Plan Validation Webhook** — a validating admission webhook at `/validate-plan` (port 9443) that impersonates the requesting user and checks `UserPermission` resources (`managedcluster:admin` / `kubevirt.io:admin`) to authorize Plan CREATE/UPDATE.
-3. **Migration Advisor API** — a plain-HTTP server (default `:8082`) at `/api/v1/migration-targets` that scores candidate clusters for a given source VM using Thanos metrics and the ACM Search API.
+1. **ManagedCluster Reconciler** — watches ManagedCluster resources labeled `acm/cnv-operator-install: "true"` and creates the ManagedServiceAccount, ClusterPermission, provider Secret, and Forklift Provider CR needed to onboard each cluster as an MTV provider.
+2. **Plan Reconciler (CCLM)** — watches Forklift Plans labeled `app.kubernetes.io/created-by: cclm` and stamps OwnerReferences on their NetworkMap and StorageMap so Kubernetes garbage-collects them when the Plan is deleted. Degrades gracefully if Forklift CRDs are not installed.
+3. **Plan Validation Webhook** — a validating admission webhook at `/validate-plan` (port 9443) that impersonates the requesting user and checks `UserPermission` resources (`managedcluster:admin` / `kubevirt.io:admin` / `kubevirt.io:edit`) to authorize Plan CREATE/UPDATE.
+4. **Migration Advisor API** — a plain-HTTP server (default `:8082`) at `/api/v1/migration-targets` that scores candidate clusters for a given source VM using Thanos metrics and the ACM Search API.
 
 The repo also ships OCM addon manifests under `addons/` (CNV addon and MTV addon) — these are pure YAML, not Go code.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,47 +2,56 @@
 
 ## System overview
 
-MTV Integrations runs as a single Deployment in the `open-cluster-management` namespace on the ACM hub cluster. It exposes three independent runtime components behind one binary (`cmd/main.go`):
+MTV Integrations runs as a single Deployment in the `open-cluster-management` namespace on the ACM hub cluster. It exposes four independent runtime components behind one binary (`cmd/main.go`):
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  mtv-integrations-controller  (single binary)           │
-│                                                         │
-│  ┌───────────────────────┐  ┌────────────────────────┐  │
-│  │  ManagedCluster        │  │  Plan Validation       │  │
-│  │  Reconciler            │  │  Webhook (:9443/TLS)   │  │
-│  │  (controller-runtime)  │  │  /validate-plan        │  │
-│  └──────────┬────────────┘  └──────────┬─────────────┘  │
-│             │                          │                 │
-│  ┌──────────┴────────────────────────────────────────┐  │
-│  │  Migration Advisor API (:8082/HTTP)               │  │
-│  │  /api/v1/migration-targets                        │  │
-│  └───────────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────┘
-        │                    │                    │
-        ▼                    ▼                    ▼
-   ManagedCluster       K8s Admission       Thanos / ACM
-   resources            API server          Search API
+┌──────────────────────────────────────────────────────────────┐
+│  mtv-integrations-controller  (single binary)                │
+│                                                              │
+│  ┌────────────────────────┐  ┌─────────────────────────────┐ │
+│  │  ManagedCluster         │  │  Plan Reconciler (CCLM)     │ │
+│  │  Reconciler             │  │  OwnerRef on NetworkMap/    │ │
+│  │  (controller-runtime)   │  │  StorageMap for cclm Plans  │ │
+│  └──────────┬─────────────┘  └──────────┬──────────────────┘ │
+│             │                           │                    │
+│  ┌──────────┴─────────────┐  ┌──────────┴──────────────────┐ │
+│  │  Plan Validation        │  │  Migration Advisor API      │ │
+│  │  Webhook (:9443/TLS)    │  │  (:8082/HTTP)               │ │
+│  │  /validate-plan         │  │  /api/v1/migration-targets  │ │
+│  └─────────────────────────┘  └─────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+        │              │              │                │
+        ▼              ▼              ▼                ▼
+   ManagedCluster  Forklift CRDs  K8s Admission   Thanos / ACM
+   resources       (Plans, Maps)  API server      Search API
 ```
 
 ## Component details
 
 ### ManagedCluster Reconciler
 
-**Trigger:** ManagedCluster labeled `mtv.konveyor.io/provider: "true"`.
+**Trigger:** ManagedCluster labeled `acm/cnv-operator-install: "true"`.
 
 **What it creates (all named `<cluster>-mtv`):**
 
-1. **ManagedServiceAccount** — in the cluster's namespace; enables token rotation for secure hub-to-spoke communication.
+1. **ManagedServiceAccount** — in the cluster's namespace on the hub; enables token rotation for secure hub-to-spoke communication.
 2. **ClusterPermission** — grants `cluster-admin` ClusterRoleBinding to the service account on the managed cluster.
-3. **Provider Secret** — in the MTV namespace (`mtv-integrations`); contains kubeconfig token, CA cert, and a `cacert` key for MTV compatibility.
-4. **Forklift Provider CR** — registers the cluster as an OpenShift-type provider in the MTV namespace.
+3. **Provider Secret** — in the `mtv-integrations` namespace; contains kubeconfig token, CA cert, and a `cacert` key for MTV compatibility.
+4. **Forklift Provider CR** — registers the cluster as an OpenShift-type provider in the `mtv-integrations` namespace.
 
 **Cleanup:** finalizer (`mtv-integrations.open-cluster-management.io/resource-cleanup`) ensures all four resources are removed when the label is removed or the cluster is deleted.
 
 **Key design choice:** Provider and ClusterPermission resources use `dynamic.Interface` with hand-built `unstructured.Unstructured` payloads (see `controllers/payloads.go`) rather than generated typed clients, because these CRDs are external and may not be installed.
 
 **Sequencing:** the Provider CR is only created after the Secret is ready (contains a valid token), ensuring authentication details are in place before MTV tries to use the provider.
+
+### Plan Reconciler (CCLM ownership)
+
+**Trigger:** Forklift Plan resources labeled `app.kubernetes.io/created-by: cclm`.
+
+**Purpose:** when the CCLM (Cluster Lifecycle Manager) creates a Plan with its associated NetworkMap and StorageMap, this controller stamps an `OwnerReference` on the NetworkMap and StorageMap pointing back to the Plan. This ensures Kubernetes garbage-collects the maps when the Plan is deleted.
+
+**Soft failure:** if Forklift CRDs are not installed on the hub, the controller logs a warning and starts a background watcher that retries when the CRDs become available, rather than failing fatally.
 
 ### Plan Validation Webhook
 
@@ -54,8 +63,8 @@ MTV Integrations runs as a single Deployment in the `open-cluster-management` na
 1. Extract destination provider name (must end with `-mtv`) → derive managed cluster name.
 2. Read `spec.targetNamespace` from the Plan.
 3. Impersonate the requesting user via a dynamic client.
-4. GET cluster-scoped `UserPermission` resources (`managedcluster:admin` and `kubevirt.io:admin` from `clusterview.open-cluster-management.io/v1alpha1`).
-5. Allow if **either** permission has a `status.bindings` entry for that cluster whose `namespaces` list includes `*` or the target namespace.
+4. GET cluster-scoped `UserPermission` resources — by default checks `managedcluster:admin`, `kubevirt.io:admin`, and `kubevirt.io:edit` (from `clusterview.open-cluster-management.io/v1alpha1`).
+5. Allow if **any** permission has a `status.bindings` entry for that cluster whose `namespaces` list includes `*` or the target namespace.
 6. Deny with a descriptive error otherwise.
 
 **Testing note:** standard Kubernetes rejects `:` in resource names, so e2e/kind tests set the `MTV_USERPERMISSION_NAMES` env var to override resource names with DNS-safe alternatives.
@@ -75,6 +84,8 @@ MTV Integrations runs as a single Deployment in the `open-cluster-management` na
 
 **Caching:** cluster-wide data (node metrics, Ceph metrics, StorageClasses) is cached with a configurable TTL (default 30s) using `singleflight` to deduplicate concurrent refreshes.
 
+**HTTP client:** `httpclient.go` builds an `*http.Client` that authenticates with the bearer token from the rest config and trusts both the cluster API server CA and the OpenShift service CA (from a mounted ConfigMap at `/var/run/secrets/service-ca/service-ca.crt`). This is required for in-cluster HTTPS services like `search-search-api` that are signed by the OpenShift Service CA.
+
 **Endpoint discovery:** at startup, `cmd/main.go` auto-discovers ACM Search API and Thanos Query Frontend via OpenShift Routes (`search-api` in `open-cluster-management`, `rbac-query-proxy` in `open-cluster-management-observability`). Flags `--search-api-endpoint` and `--thanos-host` override this for local development.
 
 ## Addons (YAML-only)
@@ -88,17 +99,27 @@ Both require ACM and the Policy addon. They are applied directly with `oc apply 
 
 ## Key data flows
 
-### Provider onboarding (reconciler)
+### Provider onboarding (ManagedCluster reconciler)
 
 ```
-ManagedCluster (label added)
+ManagedCluster (acm/cnv-operator-install=true label added)
   → Reconciler creates ManagedServiceAccount
   → MSAA controller creates ServiceAccount + token on spoke
   → Token appears in Secret on hub
   → Reconciler creates ClusterPermission (cluster-admin on spoke)
-  → Reconciler creates Provider Secret (token + CA in MTV namespace)
+  → Reconciler creates Provider Secret (token + CA in mtv-integrations namespace)
   → Reconciler creates Forklift Provider CR
   → MTV can now use the cluster as a migration source/target
+```
+
+### CCLM Plan ownership (Plan reconciler)
+
+```
+CCLM creates Plan + NetworkMap + StorageMap (all labeled created-by=cclm)
+  → Plan reconciler detects the Plan
+  → Reads spec.map.network and spec.map.storage refs
+  → Sets OwnerReference on NetworkMap and StorageMap → Plan
+  → Kubernetes GC deletes maps when Plan is deleted
 ```
 
 ### Plan authorization (webhook)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,126 @@
+# Architecture
+
+## System overview
+
+MTV Integrations runs as a single Deployment in the `open-cluster-management` namespace on the ACM hub cluster. It exposes three independent runtime components behind one binary (`cmd/main.go`):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  mtv-integrations-controller  (single binary)           │
+│                                                         │
+│  ┌───────────────────────┐  ┌────────────────────────┐  │
+│  │  ManagedCluster        │  │  Plan Validation       │  │
+│  │  Reconciler            │  │  Webhook (:9443/TLS)   │  │
+│  │  (controller-runtime)  │  │  /validate-plan        │  │
+│  └──────────┬────────────┘  └──────────┬─────────────┘  │
+│             │                          │                 │
+│  ┌──────────┴────────────────────────────────────────┐  │
+│  │  Migration Advisor API (:8082/HTTP)               │  │
+│  │  /api/v1/migration-targets                        │  │
+│  └───────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+        │                    │                    │
+        ▼                    ▼                    ▼
+   ManagedCluster       K8s Admission       Thanos / ACM
+   resources            API server          Search API
+```
+
+## Component details
+
+### ManagedCluster Reconciler
+
+**Trigger:** ManagedCluster labeled `mtv.konveyor.io/provider: "true"`.
+
+**What it creates (all named `<cluster>-mtv`):**
+
+1. **ManagedServiceAccount** — in the cluster's namespace; enables token rotation for secure hub-to-spoke communication.
+2. **ClusterPermission** — grants `cluster-admin` ClusterRoleBinding to the service account on the managed cluster.
+3. **Provider Secret** — in the MTV namespace (`mtv-integrations`); contains kubeconfig token, CA cert, and a `cacert` key for MTV compatibility.
+4. **Forklift Provider CR** — registers the cluster as an OpenShift-type provider in the MTV namespace.
+
+**Cleanup:** finalizer (`mtv-integrations.open-cluster-management.io/resource-cleanup`) ensures all four resources are removed when the label is removed or the cluster is deleted.
+
+**Key design choice:** Provider and ClusterPermission resources use `dynamic.Interface` with hand-built `unstructured.Unstructured` payloads (see `controllers/payloads.go`) rather than generated typed clients, because these CRDs are external and may not be installed.
+
+**Sequencing:** the Provider CR is only created after the Secret is ready (contains a valid token), ensuring authentication details are in place before MTV tries to use the provider.
+
+### Plan Validation Webhook
+
+**Endpoint:** `/validate-plan` on the webhook server (port 9443, TLS).
+
+**Operations:** intercepts `CREATE` and `UPDATE` of `forklift.konveyor.io/v1beta1` Plan resources.
+
+**Authorization flow:**
+1. Extract destination provider name (must end with `-mtv`) → derive managed cluster name.
+2. Read `spec.targetNamespace` from the Plan.
+3. Impersonate the requesting user via a dynamic client.
+4. GET cluster-scoped `UserPermission` resources (`managedcluster:admin` and `kubevirt.io:admin` from `clusterview.open-cluster-management.io/v1alpha1`).
+5. Allow if **either** permission has a `status.bindings` entry for that cluster whose `namespaces` list includes `*` or the target namespace.
+6. Deny with a descriptive error otherwise.
+
+**Testing note:** standard Kubernetes rejects `:` in resource names, so e2e/kind tests set the `MTV_USERPERMISSION_NAMES` env var to override resource names with DNS-safe alternatives.
+
+### Migration Advisor API
+
+**Endpoint:** `/api/v1/migration-targets` (port 8082, plain HTTP — no TLS required).
+
+**Purpose:** given a source VM (cluster, namespace, name), score all candidate ACM-managed clusters and recommend the best migration target.
+
+**Data flow:**
+1. **VM Fetcher** (`vm_fetcher.go`) — queries ACM Search API (GraphQL) to get the source VM's CPU, memory, and volumes.
+2. **Observability Client** (`observability_client.go`) — queries Thanos for per-node CPU/memory allocatable and Ceph cluster metrics across all managed clusters.
+3. **Search Client** (`search_client.go`) — queries ACM Search for StorageClass provisioners on clusters labeled `acm/cnv-operator-install=true`.
+4. **Scorer** (`scorer.go`) — filters clusters that can't fit the VM, then scores remaining candidates on CPU availability, memory availability, and storage compatibility.
+5. **Handler** (`handler.go`) — orchestrates the above, returns ranked candidates with a top recommendation.
+
+**Caching:** cluster-wide data (node metrics, Ceph metrics, StorageClasses) is cached with a configurable TTL (default 30s) using `singleflight` to deduplicate concurrent refreshes.
+
+**Endpoint discovery:** at startup, `cmd/main.go` auto-discovers ACM Search API and Thanos Query Frontend via OpenShift Routes (`search-api` in `open-cluster-management`, `rbac-query-proxy` in `open-cluster-management-observability`). Flags `--search-api-endpoint` and `--thanos-host` override this for local development.
+
+## Addons (YAML-only)
+
+Under `addons/`, two OCM AddOnTemplate manifests:
+
+- **CNV Addon** (`cnv-addon/`) — installs KubeVirt HyperConverged operator on clusters labeled `acm/cnv-operator-install: "true"`. Uses OperatorPolicy for lifecycle management.
+- **MTV Addon** (`mtv-addon/`) — installs the MTV operator in `openshift-mtv` on the hub. Enables UI plugin, validation, and volume populator features.
+
+Both require ACM and the Policy addon. They are applied directly with `oc apply -f`, not managed by the Go controller.
+
+## Key data flows
+
+### Provider onboarding (reconciler)
+
+```
+ManagedCluster (label added)
+  → Reconciler creates ManagedServiceAccount
+  → MSAA controller creates ServiceAccount + token on spoke
+  → Token appears in Secret on hub
+  → Reconciler creates ClusterPermission (cluster-admin on spoke)
+  → Reconciler creates Provider Secret (token + CA in MTV namespace)
+  → Reconciler creates Forklift Provider CR
+  → MTV can now use the cluster as a migration source/target
+```
+
+### Plan authorization (webhook)
+
+```
+User submits Plan CREATE/UPDATE
+  → API server calls /validate-plan
+  → Webhook extracts destination provider + target namespace
+  → Webhook impersonates user, GETs UserPermission resources
+  → Checks bindings for cluster + namespace match
+  → Allow or Deny
+```
+
+### Migration target scoring (advisor)
+
+```
+GET /api/v1/migration-targets?cluster=X&namespace=Y&name=Z
+  → Fetch source VM info from ACM Search API
+  → Fetch node metrics from Thanos (all clusters)
+  → Fetch Ceph metrics from Thanos
+  → Fetch StorageClasses from ACM Search
+  → Filter clusters that can't fit the VM
+  → Score remaining clusters (CPU + memory + storage)
+  → Return ranked candidates + recommendation
+```


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with build/test commands, architecture overview, testing patterns, and personal config instructions for the Fleet Engineering agentic SDLC workflow
- Add `.cursor/rules/fleet-skills.mdc` with the Fleet Engineering skills catalog for Cursor users
- Fleet Engineering plugin (`ocp-fleet-agentic-sdlc`) installed for Claude Code — all skills available as slash commands

## Test plan

- [ ] Verify `CLAUDE.md` build/lint/test commands match the actual Makefile targets
- [ ] Confirm `.cursor/rules/fleet-skills.mdc` loads correctly in Cursor
- [ ] Confirm Fleet Engineering slash commands are available in Claude Code sessions in this repo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation and added developer guidance resources for repository setup and contribution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->