### PR TITLE
feat(charts): add NetworkPolicy for mtv-integrations controller

### DIFF
--- a/charts/templates/mtv-integrations-networkpolicy.yaml
+++ b/charts/templates/mtv-integrations-networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mtv-integrations-controller
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: mtv-integrations
+    app.kubernetes.io/name: mtv-integrations
+spec:
+  podSelector:
+    matchLabels:
+      app: mtv-integrations
+      component: "ocm-mtv-integrations-ctrl"
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+        - port: 8082
+          protocol: TCP
+        - port: 8081
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a Kubernetes `NetworkPolicy` restricting ingress traffic to the `mtv-integrations-controller` pod to only the ports it actually serves:
  - `9443/TCP` – validating webhook (TLS)
  - `8443/TCP` – metrics (TLS)
  - `8082/TCP` – migration advisor HTTP API
  - `8081/TCP` – health probe
- Pod selector matches labels `app=mtv-integrations` + `component=ocm-mtv-integrations-ctrl`, consistent with the Deployment template

## Test plan

- [x] Deployed all chart templates including the new NetworkPolicy to a hub cluster
- [x] Verified pod labels match the NetworkPolicy `podSelector`
- [x] Confirmed migration advisor API (`/api/v1/migration-targets`) is reachable on port 8082 through the Route
- [x] Confirmed health endpoint (`/health`) responds on port 8082
- [x] Confirmed validating webhook (`/validate-plan`) responds on port 9443

## Related

- Jira: [ACM-31159](https://redhat.atlassian.net/browse/ACM-31159)

Made with [Cursor](https://cursor.com)

[ACM-31159]: https://redhat.atlassian.net/browse/ACM-31159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added network security configuration for the integration controller component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->