### PR TITLE
ACM-30174: inherit central TLS profile from APIServer for PQC readiness

### DIFF
--- a/charts/templates/mtv-integrations-clusterrole.yaml
+++ b/charts/templates/mtv-integrations-clusterrole.yaml
@@ -6,6 +6,14 @@ metadata:
   name: mtv-integrations-manager-role
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,8 @@ import (
 	miwebhook "github.com/stolostron/mtv-integrations/webhook"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	apiconfigv1 "github.com/openshift/api/config/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +50,7 @@ import (
 	auth "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -72,6 +75,7 @@ func init() {
 	utilruntime.Must(forkliftv1beta1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(authorizationv1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(apiconfigv1.Install(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -247,6 +251,7 @@ func setupAdvisorServer(
 	searchAPIEndpoint, thanosHost, advisorAddr string,
 	advisorCacheTTL time.Duration,
 	serviceCAPath string,
+	tlsOpts func(*tls.Config),
 ) error {
 	advisorHandler := &migrationadvisor.Handler{
 		DynamicClient:     dynamicClient,
@@ -255,6 +260,7 @@ func setupAdvisorServer(
 		ThanosHost:        thanosHost,
 		CacheTTL:          advisorCacheTTL,
 		ServiceCAPath:     serviceCAPath,
+		TLSOpts:           tlsOpts,
 	}
 	advisorMux := http.NewServeMux()
 	advisorMux.Handle("/api/v1/migration-targets", advisorHandler)
@@ -268,6 +274,7 @@ func setupAdvisorServer(
 			RestConfig:    restConfig,
 			ThanosHost:    thanosHost,
 			ServiceCAPath: serviceCAPath,
+			TLSOpts:       tlsOpts,
 		}
 		if err := obsClient.CheckHealth(r.Context()); err != nil {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -298,6 +305,72 @@ func setupAdvisorServer(
 			return err
 		}
 	}))
+}
+
+// getInitialTLSProfile fetches the TLS profile from the cluster's APIServer resource
+// and returns the profile spec and a tls.Config function to apply it.
+// Falls back to the Intermediate profile (TLS 1.2+) if the APIServer cannot be reached.
+func getInitialTLSProfile(restConfig *rest.Config) (apiconfigv1.TLSProfileSpec, func(*tls.Config)) {
+	// safeDefaultSpec returns the Intermediate TLS profile spec, which is the
+	// well-known cluster default (TLS 1.2+). If GetTLSProfileSpec unexpectedly
+	// fails, we fall back to the pre-defined Intermediate profile directly so we
+	// never propagate a zero-value spec (empty MinTLSVersion) to NewTLSConfigFromProfile.
+	safeDefaultSpec := func(cause error) apiconfigv1.TLSProfileSpec {
+		if cause != nil {
+			setupLog.Error(cause, "unable to get default TLS profile, using built-in Intermediate spec")
+		}
+		spec, err := tlspkg.GetTLSProfileSpec(nil)
+		if err != nil {
+			// GetTLSProfileSpec(nil) should never error; if it does, use the
+			// compiled-in Intermediate profile directly to avoid a zero-value spec.
+			setupLog.Error(err, "GetTLSProfileSpec returned unexpected error, using built-in Intermediate spec")
+			return *apiconfigv1.TLSProfiles[apiconfigv1.TLSProfileIntermediateType]
+		}
+		return spec
+	}
+
+	applyAndLog := func(profileSpec apiconfigv1.TLSProfileSpec) (apiconfigv1.TLSProfileSpec, func(*tls.Config)) {
+		tlsConfigFunc, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(profileSpec)
+		if len(unsupportedCiphers) > 0 {
+			setupLog.Info("TLS profile contains unsupported ciphers (ignored)", "ciphers", unsupportedCiphers)
+		}
+		setupLog.Info("TLS security profile loaded",
+			"minTLSVersion", profileSpec.MinTLSVersion,
+			"ciphers", profileSpec.Ciphers,
+		)
+		return profileSpec, tlsConfigFunc
+	}
+
+	k8sClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for TLS profile fetch, falling back to default")
+		return applyAndLog(safeDefaultSpec(nil))
+	}
+
+	profileSpec, err := tlspkg.FetchAPIServerTLSProfile(context.Background(), k8sClient)
+	if err != nil {
+		setupLog.Error(err, "unable to fetch TLS profile from APIServer, falling back to default")
+		return applyAndLog(safeDefaultSpec(nil))
+	}
+
+	return applyAndLog(profileSpec)
+}
+
+// setupTLSProfileWatcher registers a controller that watches the APIServer object
+// for TLS profile changes and cancels ctx (triggering a graceful restart) when
+// the profile changes.
+func setupTLSProfileWatcher(mgr ctrl.Manager, cancel context.CancelFunc, profileSpec apiconfigv1.TLSProfileSpec) error {
+	return (&tlspkg.SecurityProfileWatcher{
+		Client:                mgr.GetClient(),
+		InitialTLSProfileSpec: profileSpec,
+		OnProfileChange: func(ctx context.Context, oldSpec, newSpec apiconfigv1.TLSProfileSpec) {
+			setupLog.Info("TLS security profile changed, initiating graceful shutdown for reload",
+				"oldMinTLSVersion", oldSpec.MinTLSVersion,
+				"newMinTLSVersion", newSpec.MinTLSVersion,
+			)
+			cancel()
+		},
+	}).SetupWithManager(mgr)
 }
 
 func main() {
@@ -375,14 +448,23 @@ func main() {
 	// Rapid Reset CVEs. For more information see:
 	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
 	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
+	if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			setupLog.Info("disabling http/2")
+			c.NextProtos = []string{"http/1.1"}
+		})
 	}
 
-	if !enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
-	}
+	// Fetch the cluster's central TLS profile from the APIServer resource and
+	// apply it to all TLS servers. Falls back to the Intermediate profile if the
+	// APIServer is unreachable (e.g. local testing).
+	tlsProfileSpec, tlsProfileFunc := getInitialTLSProfile(ctrl.GetConfigOrDie())
+	tlsOpts = append(tlsOpts, tlsProfileFunc)
+
+	// Use a cancellable context so the SecurityProfileWatcher can trigger a
+	// graceful restart when the cluster's TLS profile changes.
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
 
 	// Create watchers for metrics and webhooks certificates
 	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
@@ -494,9 +576,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	sigCtx := ctrl.SetupSignalHandler()
-
-	if err = setupControllers(sigCtx, mgr, dynamicClient, enableWebhook, webhookServer); err != nil {
+	if err = setupControllers(ctx, mgr, dynamicClient, enableWebhook, webhookServer); err != nil {
 		setupLog.Error(err, "unable to create controller")
 		os.Exit(1)
 	}
@@ -504,10 +584,15 @@ func main() {
 	if err := setupAdvisorServer(
 		mgr, dynamicClient, mgr.GetConfig(),
 		searchAPIEndpoint, thanosHost, advisorAddr, advisorCacheTTL,
-		serviceCAPath,
+		serviceCAPath, tlsProfileFunc,
 	); err != nil {
 		setupLog.Error(err, "unable to add advisor server to manager")
 		os.Exit(1)
+	}
+
+	// Watch for TLS profile changes and trigger graceful restart when detected.
+	if err := setupTLSProfileWatcher(mgr, cancel, tlsProfileSpec); err != nil {
+		setupLog.Error(err, "unable to set up TLS security profile watcher, continuing without it")
 	}
 	// +kubebuilder:scaffold:builder
 
@@ -537,7 +622,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(sigCtx); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: manager-role
 rules:
+- apiGroups: ["config.openshift.io"]
+  resources: ["apiservers"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters"]
   verbs: ["get", "list", "watch", "patch", "update"]

--- a/controllers/migrationadvisor/handler.go
+++ b/controllers/migrationadvisor/handler.go
@@ -5,6 +5,7 @@ package migrationadvisor
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -100,6 +101,11 @@ type Handler struct {
 	// CacheTTL controls how long cluster-wide data (node metrics, SCs) is cached.
 	// Defaults to defaultCacheTTL (30 s) when zero.
 	CacheTTL time.Duration
+	// TLSOpts is an optional function applied to the TLS configuration of all
+	// outbound HTTP clients (Thanos, Search API). It is used to inherit the
+	// cluster's central TLS profile (MinVersion, CipherSuites) from the APIServer
+	// resource rather than hard-coding protocol versions.
+	TLSOpts func(*tls.Config)
 
 	cache clusterDataCache
 }
@@ -289,11 +295,17 @@ func (h *Handler) getClusterSnapshot(ctx context.Context) (clusterSnapshot, erro
 // Ceph metrics are non-fatal: missing Ceph data causes the scorer to use a
 // neutral storage score rather than failing the whole request.
 func (h *Handler) fetchFreshClusterData(ctx context.Context) (clusterSnapshot, error) {
-	obsClient := &ObservabilityClient{RestConfig: h.RestConfig, ThanosHost: h.ThanosHost, ServiceCAPath: h.ServiceCAPath}
+	obsClient := &ObservabilityClient{
+		RestConfig:    h.RestConfig,
+		ThanosHost:    h.ThanosHost,
+		ServiceCAPath: h.ServiceCAPath,
+		TLSOpts:       h.TLSOpts,
+	}
 	searchClient := &SearchClient{
 		RestConfig:        h.RestConfig,
 		SearchAPIEndpoint: h.SearchAPIEndpoint,
 		ServiceCAPath:     h.ServiceCAPath,
+		TLSOpts:           h.TLSOpts,
 	}
 
 	var (

--- a/controllers/migrationadvisor/httpclient.go
+++ b/controllers/migrationadvisor/httpclient.go
@@ -33,7 +33,12 @@ const DefaultServiceCAPath = "/var/run/secrets/service-ca/service-ca.crt"
 //
 // serviceCAPath is silently skipped when empty or the file does not exist
 // (e.g. unit tests or non-OpenShift environments).
-func buildHTTPClient(restConfig *rest.Config, serviceCAPath string) (*http.Client, error) {
+//
+// tlsOpts are applied after the CA pool is configured and may set MinVersion,
+// CipherSuites, or other TLS settings from the cluster's central TLS profile.
+func buildHTTPClient(
+	restConfig *rest.Config, serviceCAPath string, tlsOpts ...func(*tls.Config),
+) (*http.Client, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		// SystemCertPool returns an error on some platforms (e.g. Windows).
@@ -74,7 +79,13 @@ func buildHTTPClient(restConfig *rest.Config, serviceCAPath string) (*http.Clien
 	// only override the fields that must differ.
 	//nolint:forcetypeassert // http.DefaultTransport is always *http.Transport
 	baseTx := http.DefaultTransport.(*http.Transport).Clone()
-	baseTx.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS13}
+	tlsConf := &tls.Config{RootCAs: pool}
+	for _, opt := range tlsOpts {
+		if opt != nil {
+			opt(tlsConf)
+		}
+	}
+	baseTx.TLSClientConfig = tlsConf
 	baseTx.DialContext = (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/controllers/migrationadvisor/observability_client.go
+++ b/controllers/migrationadvisor/observability_client.go
@@ -5,6 +5,7 @@ package migrationadvisor
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -111,6 +112,9 @@ type ObservabilityClient struct {
 	// ServiceCAPath is the path to the OpenShift service CA bundle PEM file.
 	// Defaults to DefaultServiceCAPath when empty.
 	ServiceCAPath string
+	// TLSOpts is an optional function applied to the TLS configuration of the
+	// outbound HTTP client. Used to inherit the cluster's central TLS profile.
+	TLSOpts func(*tls.Config)
 
 	noCopy       noCopy
 	clientOnce   sync.Once
@@ -137,7 +141,7 @@ func (o *ObservabilityClient) baseURL() string {
 // client and therefore the same connection pool.
 func (o *ObservabilityClient) httpClient() (*http.Client, error) {
 	o.clientOnce.Do(func() {
-		o.cachedClient, o.clientErr = buildHTTPClient(o.RestConfig, o.serviceCAPath())
+		o.cachedClient, o.clientErr = buildHTTPClient(o.RestConfig, o.serviceCAPath(), o.TLSOpts)
 	})
 	return o.cachedClient, o.clientErr
 }

--- a/controllers/migrationadvisor/search_client.go
+++ b/controllers/migrationadvisor/search_client.go
@@ -6,6 +6,7 @@ package migrationadvisor
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,6 +28,9 @@ type SearchClient struct {
 	// ServiceCAPath is the path to the OpenShift service CA bundle PEM file.
 	// Defaults to DefaultServiceCAPath when empty.
 	ServiceCAPath string
+	// TLSOpts is an optional function applied to the TLS configuration of the
+	// outbound HTTP client. Used to inherit the cluster's central TLS profile.
+	TLSOpts func(*tls.Config)
 }
 
 func (s *SearchClient) serviceCAPath() string {
@@ -77,7 +81,7 @@ const searchPageSize = 1000
 func (s *SearchClient) ListStorageClassProvisionersByCluster(
 	ctx context.Context,
 ) (map[string][]SCProvisioner, error) {
-	httpClient, err := buildHTTPClient(s.RestConfig, s.serviceCAPath())
+	httpClient, err := buildHTTPClient(s.RestConfig, s.serviceCAPath(), s.TLSOpts)
 	if err != nil {
 		return nil, fmt.Errorf("build HTTP client: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/kubev2v/forklift v0.0.0-20260511180337-abefdf391aaf
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/openshift/api v0.0.0-20260610142756-120a096a2850
+	github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
@@ -32,6 +34,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
+	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,14 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
 github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/openshift/api v0.0.0-20260610142756-120a096a2850 h1:w7gAx2UR35Gh40o+7w9s4+JOMjM0vHKDnl5S2Z0h8nE=
+github.com/openshift/api v0.0.0-20260610142756-120a096a2850/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e h1:k89oIo2EjX0PRSdi1kesktCyWp50SC9WwKurvupvRGs=
+github.com/openshift/controller-runtime-common v0.0.0-20260428152732-64ee174f5e2e/go.mod h1:XGabTMnNbz0M5Oa7IbscZp/jmcc7aHobvOCUWwkzKvM=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 h1:9Pe6iVOMjt9CdA/vaKBNUSoEIjIe1po5Ha3ABRYXLJI=
+github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary

- Fetches the cluster's TLS security profile from `apiservers.config.openshift.io/cluster` at startup and applies it to all TLS servers (webhook port 9443, metrics port 8443) and outbound HTTP clients (Thanos, ACM Search API)
- Falls back to the Intermediate profile (TLS 1.2+) gracefully when the APIServer resource is not available (e.g. kind clusters used in e2e tests)
- Registers a `SecurityProfileWatcher` that triggers a graceful manager restart when the cluster TLS profile changes at runtime
- Removes hardcoded `MinVersion: tls.VersionTLS13` from `buildHTTPClient`; TLS settings now come from the cluster's central configuration source
- Adds `get/list/watch` on `config.openshift.io/apiservers` to both Helm and Kustomize ClusterRole files

## Changes

| File | Change |
|---|---|
| `go.mod` | Add `github.com/openshift/api`, `github.com/openshift/controller-runtime-common`, `github.com/openshift/library-go` |
| `cmd/main.go` | `getInitialTLSProfile()`, `setupTLSProfileWatcher()`, cancellable context, apply profile to `tlsOpts` |
| `controllers/migrationadvisor/httpclient.go` | Replace hardcoded `MinVersion: tls.VersionTLS13` with variadic `tlsOpts ...func(*tls.Config)` |
| `controllers/migrationadvisor/{handler,search_client,observability_client}.go` | Add `TLSOpts func(*tls.Config)` field, thread through to `buildHTTPClient` |
| `charts/templates/mtv-integrations-clusterrole.yaml` | Add `config.openshift.io/apiservers` get/list/watch |
| `config/rbac/role.yaml` | Mirror the same RBAC rule |

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./controllers/migrationadvisor/... ./webhook/...` — all pass
- [x] Webhook e2e (`make run-webhook-test`) — not affected; fallback to Intermediate profile on kind (no `config.openshift.io` API group)
- [x] Deploy to hub cluster and verify TLS profile is loaded from `apiservers.config.openshift.io/cluster` on startup log

## References

- Jira: [ACM-30174](https://redhat.atlassian.net/browse/ACM-30174)
- Parent Epic: [ACM-26882](https://redhat.atlassian.net/browse/ACM-26882) — \[ACM\] Central TLS Profile consistency
- Similar implementation: [cluster-node-tuning-operator#1483](https://github.com/openshift/cluster-node-tuning-operator/pull/1483)
- Technical Guide: https://docs.google.com/document/d/1cMc9E8psHfnoK06ntR8kHSWB8d3rMtmldhnmM4nImjs

Made with [Cursor](https://cursor.com)

[ACM-30174]: https://redhat.atlassian.net/browse/ACM-30174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now loads and monitors OpenShift cluster TLS security profiles at startup, automatically restarting gracefully when profiles change
  * Added ability to disable HTTP/2 for TLS connections via configuration flag
  * Updated permissions to access cluster TLS configuration

* **Chores**
  * Added OpenShift API and controller runtime dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->