### PR TITLE
feat(advisor): add RBAC gate to migration-advisor API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,10 +368,8 @@ run-e2e-test: e2e-dependencies run-instrument
 
 .PHONY: run-advisor-test
 run-advisor-test: e2e-dependencies ## Run migration advisor API e2e tests (requires prepare-e2e-test).
-	# Apply the DNS-safe UserPermission fixture (kind rejects ':' in resource names).
-	$(KUBECTL) apply -f test/resources/migration_advisor/userpermission.yaml
 	@set -e; \
-	trap '$(MAKE) stop-fake-search; $(MAKE) stop-fake-thanos; $(MAKE) exit-instrument' EXIT; \
+	trap '$(KUBECTL) delete -f test/resources/migration_advisor/userpermission.yaml --ignore-not-found; $(MAKE) stop-fake-search; $(MAKE) stop-fake-thanos; $(MAKE) exit-instrument' EXIT; \
 	$(MAKE) start-fake-search; \
 	$(MAKE) start-fake-thanos; \
 	export MTV_ADVISOR_ROLE_VM_FLEET_ADMIN=acm-vm-fleet-admin; \

--- a/Makefile
+++ b/Makefile
@@ -368,10 +368,13 @@ run-e2e-test: e2e-dependencies run-instrument
 
 .PHONY: run-advisor-test
 run-advisor-test: e2e-dependencies ## Run migration advisor API e2e tests (requires prepare-e2e-test).
+	# Apply the DNS-safe UserPermission fixture (kind rejects ':' in resource names).
+	$(KUBECTL) apply -f test/resources/migration_advisor/userpermission.yaml
 	@set -e; \
 	trap '$(MAKE) stop-fake-search; $(MAKE) stop-fake-thanos; $(MAKE) exit-instrument' EXIT; \
 	$(MAKE) start-fake-search; \
 	$(MAKE) start-fake-thanos; \
+	export MTV_ADVISOR_ROLE_VM_FLEET_ADMIN=acm-vm-fleet-admin; \
 	$(MAKE) run-instrument THANOS_HOST=$(FAKE_THANOS_HOST) SEARCH_API_ENDPOINT=$(FAKE_SEARCH_HOST)/searchapi/graphql; \
 	$(GINKGO) -v --fail-fast --label-filter="migration_advisor" --json-report=report_advisor.json -timeout 120s test/e2e; \
 	go tool covdata textfmt -i=coverage_profiles -o=coverage_e2e.out || true

--- a/controllers/migrationadvisor/handler.go
+++ b/controllers/migrationadvisor/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stolostron/mtv-integrations/api"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -129,14 +130,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log = log.WithValues("vm", req.VMName, "namespace", req.VMNamespace, "cluster", req.ClusterName)
 	ctx := ctrl.LoggerInto(r.Context(), log)
 
-	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-	if token == "" {
+	parts := strings.Fields(r.Header.Get("Authorization"))
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || parts[1] == "" {
 		http.Error(w, "authorization required", http.StatusUnauthorized)
 		return
 	}
+	token := parts[1]
 
 	allowed, err := checkCallerAuthorized(ctx, h.DynamicClient, h.RestConfig, token)
 	if err != nil {
+		if apierrors.IsUnauthorized(err) {
+			http.Error(w, "authorization required", http.StatusUnauthorized)
+			return
+		}
 		log.Error(err, "authorization check failed")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/controllers/migrationadvisor/handler.go
+++ b/controllers/migrationadvisor/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,6 +128,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	log = log.WithValues("vm", req.VMName, "namespace", req.VMNamespace, "cluster", req.ClusterName)
 	ctx := ctrl.LoggerInto(r.Context(), log)
+
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token == "" {
+		http.Error(w, "authorization required", http.StatusUnauthorized)
+		return
+	}
+
+	allowed, err := checkCallerAuthorized(ctx, h.DynamicClient, h.RestConfig, token)
+	if err != nil {
+		log.Error(err, "authorization check failed")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	if !allowed {
+		http.Error(w, "forbidden: requires acm-vm-fleet:admin or cluster-admin for all CNV clusters",
+			http.StatusForbidden)
+		return
+	}
 
 	resp, err := h.evaluate(ctx, req)
 	if err != nil {

--- a/controllers/migrationadvisor/handler_test.go
+++ b/controllers/migrationadvisor/handler_test.go
@@ -291,7 +291,7 @@ func TestServeHTTP_EvaluateVMNotFound(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
-	authSrv := newFakeUserPermissionServer(t, // fleet admin
+	authSrv := newFakeUserPermissionServer(t, "test-token", // fleet admin
 		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
 	defer authSrv.Close()
 
@@ -325,7 +325,7 @@ func TestServeHTTP_EvaluateServerError(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
-	authSrv := newFakeUserPermissionServer(t, // fleet admin
+	authSrv := newFakeUserPermissionServer(t, "test-token", // fleet admin
 		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
 	defer authSrv.Close()
 
@@ -359,7 +359,7 @@ func TestServeHTTP_EvaluateSuccess(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
-	authSrv := newFakeUserPermissionServer(t, // fleet admin
+	authSrv := newFakeUserPermissionServer(t, "test-token", // fleet admin
 		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
 	defer authSrv.Close()
 

--- a/controllers/migrationadvisor/handler_test.go
+++ b/controllers/migrationadvisor/handler_test.go
@@ -117,6 +117,7 @@ func TestServeHTTP_MissingParams(t *testing.T) {
 
 // ── getClusterSnapshot / fetchFreshClusterData ───────────────────────────────
 
+
 // newFakeSearchServer creates an httptest server mimicking the ACM Search API.
 func newFakeSearchServer(t *testing.T, clusters []string) *httptest.Server {
 	t.Helper()
@@ -290,6 +291,9 @@ func TestServeHTTP_EvaluateVMNotFound(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
+	authSrv := newFakeUserPermissionServer(t, // fleet admin
+		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
+	defer authSrv.Close()
 
 	fakeClient := newFakeClientWithMCV(
 		func(_ k8stesting.Action) (bool, runtime.Object, error) {
@@ -299,13 +303,14 @@ func TestServeHTTP_EvaluateVMNotFound(t *testing.T) {
 
 	h := &Handler{
 		DynamicClient:     fakeClient,
-		RestConfig:        &rest.Config{Host: thanosSrv.URL},
+		RestConfig:        &rest.Config{Host: authSrv.URL},
 		ThanosHost:        thanosSrv.URL,
 		SearchAPIEndpoint: searchSrv.URL + "/searchapi/graphql",
 	}
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/migration-targets?cluster=nonexistent-cluster&vmNamespace=default&vmName=vm1", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -320,6 +325,9 @@ func TestServeHTTP_EvaluateServerError(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
+	authSrv := newFakeUserPermissionServer(t, // fleet admin
+		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
+	defer authSrv.Close()
 
 	fakeClient := newFakeClientWithMCV(
 		func(_ k8stesting.Action) (bool, runtime.Object, error) {
@@ -329,13 +337,14 @@ func TestServeHTTP_EvaluateServerError(t *testing.T) {
 
 	h := &Handler{
 		DynamicClient:     fakeClient,
-		RestConfig:        &rest.Config{Host: thanosSrv.URL},
+		RestConfig:        &rest.Config{Host: authSrv.URL},
 		ThanosHost:        thanosSrv.URL,
 		SearchAPIEndpoint: searchSrv.URL + "/searchapi/graphql",
 	}
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/migration-targets?cluster=c1&vmNamespace=default&vmName=vm1", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -350,6 +359,9 @@ func TestServeHTTP_EvaluateSuccess(t *testing.T) {
 	defer thanosSrv.Close()
 	searchSrv := newFakeSearchServer(t, []string{})
 	defer searchSrv.Close()
+	authSrv := newFakeUserPermissionServer(t, // fleet admin
+		map[string][]string{advisorRoleVMFleetAdmin(): {hubClusterName}})
+	defer authSrv.Close()
 
 	fakeClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), dummyManagedCluster)
 	injectWatchEvent(fakeClient, mcvWithResult(map[string]interface{}{
@@ -360,13 +372,14 @@ func TestServeHTTP_EvaluateSuccess(t *testing.T) {
 
 	h := &Handler{
 		DynamicClient:     fakeClient,
-		RestConfig:        &rest.Config{Host: thanosSrv.URL},
+		RestConfig:        &rest.Config{Host: authSrv.URL},
 		ThanosHost:        thanosSrv.URL,
 		SearchAPIEndpoint: searchSrv.URL + "/searchapi/graphql",
 	}
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/migration-targets?cluster=c1&vmNamespace=default&vmName=vm1", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 

--- a/controllers/migrationadvisor/rbac.go
+++ b/controllers/migrationadvisor/rbac.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,9 @@ func checkCallerAuthorized(
 	baseConfig *rest.Config,
 	bearerToken string,
 ) (bool, error) {
+	authCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	callerCfg := rest.CopyConfig(baseConfig)
 	callerCfg.BearerToken = bearerToken
 	callerCfg.BearerTokenFile = ""
@@ -75,11 +79,11 @@ func checkCallerAuthorized(
 		return false, fmt.Errorf("build caller dynamic client: %w", err)
 	}
 
-	if ok, err := userPermissionCoversHub(ctx, callerClient); err != nil || ok {
+	if ok, err := userPermissionCoversHub(authCtx, callerClient); err != nil || ok {
 		return ok, err
 	}
 
-	return callerIsClusterAdmin(ctx, controllerClient, callerClient)
+	return callerIsClusterAdmin(authCtx, controllerClient, callerClient)
 }
 
 // userPermissionCoversHub returns true when the caller's acm-vm-fleet:admin
@@ -94,13 +98,22 @@ func userPermissionCoversHub(ctx context.Context, callerClient dynamic.Interface
 		return false, fmt.Errorf("get UserPermission %q: %w", roleName, err)
 	}
 
-	bindings, _, _ := unstructured.NestedSlice(obj.Object, "status", "bindings")
+	bindings, found, err := unstructured.NestedSlice(obj.Object, "status", "bindings")
+	if err != nil {
+		return false, fmt.Errorf("decode UserPermission %q bindings: %w", roleName, err)
+	}
+	if !found {
+		return false, nil
+	}
 	for _, raw := range bindings {
 		binding, ok := raw.(map[string]interface{})
 		if !ok {
-			continue
+			return false, fmt.Errorf("decode UserPermission %q binding: unexpected %T", roleName, raw)
 		}
-		cluster, _, _ := unstructured.NestedString(binding, "cluster")
+		cluster, _, err := unstructured.NestedString(binding, "cluster")
+		if err != nil {
+			return false, fmt.Errorf("decode UserPermission %q binding cluster: %w", roleName, err)
+		}
 		if cluster == hubClusterName {
 			return true, nil
 		}
@@ -135,10 +148,20 @@ func callerIsClusterAdmin(
 	}
 
 	covered := make(map[string]struct{})
-	bindings, _, _ := unstructured.NestedSlice(obj.Object, "status", "bindings")
-	for _, raw := range bindings {
-		if b, ok := raw.(map[string]interface{}); ok {
-			cluster, _, _ := unstructured.NestedString(b, "cluster")
+	bindings, found, err := unstructured.NestedSlice(obj.Object, "status", "bindings")
+	if err != nil {
+		return false, fmt.Errorf("decode UserPermission %q bindings: %w", roleName, err)
+	}
+	if found {
+		for _, raw := range bindings {
+			b, ok := raw.(map[string]interface{})
+			if !ok {
+				return false, fmt.Errorf("decode UserPermission %q binding: unexpected %T", roleName, raw)
+			}
+			cluster, _, err := unstructured.NestedString(b, "cluster")
+			if err != nil {
+				return false, fmt.Errorf("decode UserPermission %q binding cluster: %w", roleName, err)
+			}
 			covered[cluster] = struct{}{}
 		}
 	}

--- a/controllers/migrationadvisor/rbac.go
+++ b/controllers/migrationadvisor/rbac.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migrationadvisor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// advisorUserPermissionGVR is the GVR for ACM clusterview UserPermission objects.
+var advisorUserPermissionGVR = schema.GroupVersionResource{
+	Group:    "clusterview.open-cluster-management.io",
+	Version:  "v1alpha1",
+	Resource: "userpermissions",
+}
+
+const (
+	hubClusterName = "local-cluster"
+
+	// Default UserPermission resource names. Standard Kubernetes rejects ':' in
+	// metadata.name, so kind/e2e tests override these via MTV_ADVISOR_ROLE_VM_FLEET_ADMIN
+	// and MTV_ADVISOR_ROLE_CLUSTER_ADMIN env vars with DNS-safe alternatives.
+	defaultRoleVMFleetAdmin       = "acm-vm-fleet:admin"
+	defaultRoleManagedClusterAdmin = "managedcluster:admin"
+)
+
+// advisorRoleVMFleetAdmin returns the UserPermission name for the fleet-admin
+// role, overridable via MTV_ADVISOR_ROLE_VM_FLEET_ADMIN for kind/e2e.
+func advisorRoleVMFleetAdmin() string {
+	if v := strings.TrimSpace(os.Getenv("MTV_ADVISOR_ROLE_VM_FLEET_ADMIN")); v != "" {
+		return v
+	}
+	return defaultRoleVMFleetAdmin
+}
+
+// advisorRoleManagedClusterAdmin returns the UserPermission name for the
+// cluster-admin role, overridable via MTV_ADVISOR_ROLE_CLUSTER_ADMIN for kind/e2e.
+func advisorRoleManagedClusterAdmin() string {
+	if v := strings.TrimSpace(os.Getenv("MTV_ADVISOR_ROLE_CLUSTER_ADMIN")); v != "" {
+		return v
+	}
+	return defaultRoleManagedClusterAdmin
+}
+
+// checkCallerAuthorized returns true when the bearer-token caller holds either:
+//  1. acm-vm-fleet:admin with a local-cluster binding, or
+//  2. managedcluster:admin covering every CNV-enabled managed cluster.
+//
+// A separate dynamic client is built from the caller's own token so RBAC is
+// evaluated as the calling user, not the controller SA.
+func checkCallerAuthorized(
+	ctx context.Context,
+	controllerClient dynamic.Interface,
+	baseConfig *rest.Config,
+	bearerToken string,
+) (bool, error) {
+	callerCfg := rest.CopyConfig(baseConfig)
+	callerCfg.BearerToken = bearerToken
+	callerCfg.BearerTokenFile = ""
+	callerCfg.Impersonate = rest.ImpersonationConfig{}
+
+	callerClient, err := dynamic.NewForConfig(callerCfg)
+	if err != nil {
+		return false, fmt.Errorf("build caller dynamic client: %w", err)
+	}
+
+	if ok, err := userPermissionCoversHub(ctx, callerClient); err != nil || ok {
+		return ok, err
+	}
+
+	return callerIsClusterAdmin(ctx, controllerClient, callerClient)
+}
+
+// userPermissionCoversHub returns true when the caller's acm-vm-fleet:admin
+// UserPermission has a local-cluster binding.
+func userPermissionCoversHub(ctx context.Context, callerClient dynamic.Interface) (bool, error) {
+	roleName := advisorRoleVMFleetAdmin()
+	obj, err := callerClient.Resource(advisorUserPermissionGVR).Get(ctx, roleName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get UserPermission %q: %w", roleName, err)
+	}
+
+	bindings, _, _ := unstructured.NestedSlice(obj.Object, "status", "bindings")
+	for _, raw := range bindings {
+		binding, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cluster, _, _ := unstructured.NestedString(binding, "cluster")
+		if cluster == hubClusterName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// callerIsClusterAdmin returns true when the caller's managedcluster:admin
+// UserPermission covers every CNV-enabled managed cluster
+// (acm/cnv-operator-install=true). The cluster list is fetched via the
+// privileged controllerClient since the caller may lack list permission.
+func callerIsClusterAdmin(
+	ctx context.Context,
+	controllerClient dynamic.Interface,
+	callerClient dynamic.Interface,
+) (bool, error) {
+	cnvClusters, err := listCNVManagedClusters(ctx, controllerClient)
+	if err != nil {
+		return false, fmt.Errorf("list CNV managed clusters: %w", err)
+	}
+	if len(cnvClusters) == 0 {
+		return false, nil
+	}
+
+	roleName := advisorRoleManagedClusterAdmin()
+	obj, err := callerClient.Resource(advisorUserPermissionGVR).Get(ctx, roleName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get UserPermission %q: %w", roleName, err)
+	}
+
+	covered := make(map[string]struct{})
+	bindings, _, _ := unstructured.NestedSlice(obj.Object, "status", "bindings")
+	for _, raw := range bindings {
+		if b, ok := raw.(map[string]interface{}); ok {
+			cluster, _, _ := unstructured.NestedString(b, "cluster")
+			covered[cluster] = struct{}{}
+		}
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	for cluster := range cnvClusters {
+		if _, ok := covered[cluster]; !ok {
+			log.Info("authorization denied: caller lacks managedcluster:admin", "cluster", cluster)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// listCNVManagedClusters returns the names of ManagedClusters labelled
+// acm/cnv-operator-install=true.
+func listCNVManagedClusters(ctx context.Context, client dynamic.Interface) (map[string]struct{}, error) {
+	list, err := client.Resource(managedClusterGVR).List(ctx, metav1.ListOptions{
+		LabelSelector: cnvOperatorInstallLabel + "=true",
+	})
+	if err != nil {
+		return nil, err
+	}
+	clusters := make(map[string]struct{}, len(list.Items))
+	for i := range list.Items {
+		clusters[list.Items[i].GetName()] = struct{}{}
+	}
+	return clusters, nil
+}

--- a/controllers/migrationadvisor/rbac_test.go
+++ b/controllers/migrationadvisor/rbac_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,8 +27,17 @@ import (
 // GET /apis/clusterview.open-cluster-management.io/v1alpha1/userpermissions/<name>.
 //
 // roleBindings maps each role name to the cluster names that appear in its
-// status.bindings. A role not present in the map returns an empty binding.
-func newFakeUserPermissionServer(t *testing.T, roleBindings map[string][]string) *httptest.Server {
+// status.bindings. A role not present in the map returns an empty binding list.
+//
+// When expectedToken is non-empty the server validates that the incoming
+// Authorization header is exactly "Bearer <expectedToken>" and returns 401
+// otherwise. Pass "" to skip token validation (e.g. in unit tests that call
+// helper functions directly without a bearer token).
+func newFakeUserPermissionServer(
+	t *testing.T,
+	expectedToken string,
+	roleBindings map[string][]string,
+) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		const prefix = "/apis/clusterview.open-cluster-management.io/v1alpha1/userpermissions/"
@@ -35,8 +45,15 @@ func newFakeUserPermissionServer(t *testing.T, roleBindings map[string][]string)
 			http.Error(w, "unexpected: "+r.Method+" "+r.URL.Path, http.StatusNotFound)
 			return
 		}
+		if expectedToken != "" {
+			got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			if got != expectedToken {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
 		roleName := r.URL.Path[len(prefix):]
-		var bindings []interface{}
+		bindings := make([]interface{}, 0) // encode as [] not null
 		for _, cluster := range roleBindings[roleName] {
 			bindings = append(bindings, map[string]interface{}{
 				"cluster":    cluster,
@@ -122,7 +139,7 @@ func TestServeHTTP_RBAC_Denied(t *testing.T) {
 	defer searchSrv.Close()
 
 	// No bindings for either role → denied.
-	upSrv := newFakeUserPermissionServer(t, nil)
+	upSrv := newFakeUserPermissionServer(t, "unprivileged-token", nil)
 	defer upSrv.Close()
 
 	// CNV cluster exists so the cluster-admin path is reachable but fails.
@@ -149,7 +166,7 @@ func TestServeHTTP_RBAC_VMFleetAdminAllowed(t *testing.T) {
 	defer searchSrv.Close()
 
 	// acm-vm-fleet:admin has local-cluster binding → fleet admin.
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "fleet-admin-token", map[string][]string{
 		advisorRoleVMFleetAdmin(): {hubClusterName},
 	})
 	defer upSrv.Close()
@@ -167,8 +184,8 @@ func TestServeHTTP_RBAC_VMFleetAdminAllowed(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
-	assert.NotEqual(t, http.StatusForbidden, w.Code)
+	// RBAC passed; fake MCV returns NotFound → VMNotFoundError → 400.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // TestServeHTTP_RBAC_ClusterAdminAllowed verifies that a caller whose
@@ -182,7 +199,7 @@ func TestServeHTTP_RBAC_ClusterAdminAllowed(t *testing.T) {
 
 	// acm-vm-fleet:admin → no local-cluster (not fleet admin).
 	// managedcluster:admin → covers "spoke01" (the only CNV cluster).
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "cluster-admin-token", map[string][]string{
 		advisorRoleManagedClusterAdmin(): {"spoke01", hubClusterName},
 	})
 	defer upSrv.Close()
@@ -201,8 +218,8 @@ func TestServeHTTP_RBAC_ClusterAdminAllowed(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
-	assert.NotEqual(t, http.StatusForbidden, w.Code)
+	// RBAC passed; fake MCV returns NotFound → VMNotFoundError → 400.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // TestServeHTTP_RBAC_ClusterAdminDenied_MissingCluster verifies that a caller
@@ -214,7 +231,7 @@ func TestServeHTTP_RBAC_ClusterAdminDenied_MissingCluster(t *testing.T) {
 	defer searchSrv.Close()
 
 	// managedcluster:admin covers only "spoke01", but "spoke02" also has CNV.
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "partial-admin-token", map[string][]string{
 		advisorRoleManagedClusterAdmin(): {"spoke01"},
 	})
 	defer upSrv.Close()
@@ -256,7 +273,7 @@ func TestServeHTTP_RBAC_AuthServerError(t *testing.T) {
 // ── userPermissionCoversHub unit tests ───────────────────────────────────────
 
 func TestUserPermissionCoversHub_LocalClusterBinding(t *testing.T) {
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "", map[string][]string{
 		advisorRoleVMFleetAdmin(): {hubClusterName},
 	})
 	defer upSrv.Close()
@@ -271,7 +288,7 @@ func TestUserPermissionCoversHub_LocalClusterBinding(t *testing.T) {
 
 func TestUserPermissionCoversHub_NoLocalClusterBinding(t *testing.T) {
 	// acm-vm-fleet:admin exists but only for a spoke cluster.
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "", map[string][]string{
 		advisorRoleVMFleetAdmin(): {"spoke01"},
 	})
 	defer upSrv.Close()
@@ -316,7 +333,7 @@ func TestCallerIsClusterAdmin_AllCNVClustersCovers(t *testing.T) {
 	)
 
 	// Caller's managedcluster:admin covers "spoke01".
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "", map[string][]string{
 		advisorRoleManagedClusterAdmin(): {"spoke01", hubClusterName},
 	})
 	defer upSrv.Close()
@@ -355,7 +372,7 @@ func TestCallerIsClusterAdmin_MissingOneCluster(t *testing.T) {
 	)
 
 	// Caller's managedcluster:admin covers only "spoke01" — missing "spoke02".
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "", map[string][]string{
 		advisorRoleManagedClusterAdmin(): {"spoke01"},
 	})
 	defer upSrv.Close()
@@ -385,7 +402,7 @@ func TestCallerIsClusterAdmin_NoCNVClusters(t *testing.T) {
 		},
 	)
 
-	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+	upSrv := newFakeUserPermissionServer(t, "", map[string][]string{
 		advisorRoleManagedClusterAdmin(): {hubClusterName},
 	})
 	defer upSrv.Close()

--- a/controllers/migrationadvisor/rbac_test.go
+++ b/controllers/migrationadvisor/rbac_test.go
@@ -1,0 +1,448 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package migrationadvisor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newFakeUserPermissionServer creates an httptest server that handles
+// GET /apis/clusterview.open-cluster-management.io/v1alpha1/userpermissions/<name>.
+//
+// roleBindings maps each role name to the cluster names that appear in its
+// status.bindings. A role not present in the map returns an empty binding.
+func newFakeUserPermissionServer(t *testing.T, roleBindings map[string][]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/apis/clusterview.open-cluster-management.io/v1alpha1/userpermissions/"
+		if r.Method != http.MethodGet || len(r.URL.Path) <= len(prefix) {
+			http.Error(w, "unexpected: "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		roleName := r.URL.Path[len(prefix):]
+		var bindings []interface{}
+		for _, cluster := range roleBindings[roleName] {
+			bindings = append(bindings, map[string]interface{}{
+				"cluster":    cluster,
+				"namespaces": []interface{}{"*"},
+			})
+		}
+		resp := map[string]interface{}{
+			"apiVersion": "clusterview.open-cluster-management.io/v1alpha1",
+			"kind":       "UserPermission",
+			"metadata":   map[string]interface{}{"name": roleName},
+			"status":     map[string]interface{}{"bindings": bindings},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("fake UP server: encode: %v", err)
+		}
+	}))
+}
+
+// newFakeAuthHandlerWithMCV builds a Handler pointing at the given fake
+// UserPermission server. The handler uses fakeClient as its controller
+// DynamicClient and the fake servers for Thanos/Search.
+func newFakeAuthHandlerWithMCV(
+	t *testing.T,
+	upSrv *httptest.Server,
+	fakeClient *dynamicfake.FakeDynamicClient,
+	thanosSrv *httptest.Server,
+	searchSrv *httptest.Server,
+) *Handler {
+	t.Helper()
+	return &Handler{
+		DynamicClient:     fakeClient,
+		RestConfig:        &rest.Config{Host: upSrv.URL},
+		ThanosHost:        thanosSrv.URL,
+		SearchAPIEndpoint: searchSrv.URL + "/searchapi/graphql",
+	}
+}
+
+// newCNVClusterFakeClient creates a fake dynamic client seeded with a
+// ManagedCluster that carries the CNV install label.
+func newCNVClusterFakeClient(
+	clusterName string,
+	extraReactors ...k8stesting.ReactionFunc,
+) *dynamicfake.FakeDynamicClient {
+	cnvCluster := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cluster.open-cluster-management.io/v1",
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name":   clusterName,
+				"labels": map[string]interface{}{cnvOperatorInstallLabel: "true"},
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	c := dynamicfake.NewSimpleDynamicClient(scheme, cnvCluster, dummyManagedCluster)
+	for _, r := range extraReactors {
+		c.PrependReactor("create", "managedclusterviews", r)
+	}
+	return c
+}
+
+// ── ServeHTTP RBAC gate ───────────────────────────────────────────────────────
+
+// TestServeHTTP_RBAC_NoToken verifies that a request without an Authorization
+// header receives HTTP 401 Unauthorized.
+func TestServeHTTP_RBAC_NoToken(t *testing.T) {
+	h := &Handler{RestConfig: &rest.Config{Host: "http://unused"}}
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "authorization required")
+}
+
+// TestServeHTTP_RBAC_Denied verifies that a caller without acm-vm-fleet:admin
+// or managedcluster:admin for all CNV clusters receives HTTP 403.
+func TestServeHTTP_RBAC_Denied(t *testing.T) {
+	thanosSrv := newFakeThanosServer(t)
+	defer thanosSrv.Close()
+	searchSrv := newFakeSearchServer(t, []string{})
+	defer searchSrv.Close()
+
+	// No bindings for either role → denied.
+	upSrv := newFakeUserPermissionServer(t, nil)
+	defer upSrv.Close()
+
+	// CNV cluster exists so the cluster-admin path is reachable but fails.
+	fakeClient := newCNVClusterFakeClient("spoke01")
+	h := newFakeAuthHandlerWithMCV(t, upSrv, fakeClient, thanosSrv, searchSrv)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	req.Header.Set("Authorization", "Bearer unprivileged-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "forbidden")
+}
+
+// TestServeHTTP_RBAC_VMFleetAdminAllowed verifies that a caller whose
+// acm-vm-fleet:admin UserPermission contains a local-cluster binding proceeds
+// past the RBAC gate.
+func TestServeHTTP_RBAC_VMFleetAdminAllowed(t *testing.T) {
+	thanosSrv := newFakeThanosServer(t)
+	defer thanosSrv.Close()
+	searchSrv := newFakeSearchServer(t, []string{})
+	defer searchSrv.Close()
+
+	// acm-vm-fleet:admin has local-cluster binding → fleet admin.
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleVMFleetAdmin(): {hubClusterName},
+	})
+	defer upSrv.Close()
+
+	fakeClient := newFakeClientWithMCV(
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(mcvGR, "c1")
+		},
+	)
+	h := newFakeAuthHandlerWithMCV(t, upSrv, fakeClient, thanosSrv, searchSrv)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	req.Header.Set("Authorization", "Bearer fleet-admin-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
+// TestServeHTTP_RBAC_ClusterAdminAllowed verifies that a caller whose
+// managedcluster:admin UserPermission covers ALL CNV-enabled managed clusters
+// proceeds past the RBAC gate (cluster-admin path).
+func TestServeHTTP_RBAC_ClusterAdminAllowed(t *testing.T) {
+	thanosSrv := newFakeThanosServer(t)
+	defer thanosSrv.Close()
+	searchSrv := newFakeSearchServer(t, []string{})
+	defer searchSrv.Close()
+
+	// acm-vm-fleet:admin → no local-cluster (not fleet admin).
+	// managedcluster:admin → covers "spoke01" (the only CNV cluster).
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleManagedClusterAdmin(): {"spoke01", hubClusterName},
+	})
+	defer upSrv.Close()
+
+	// Controller sees "spoke01" as the only CNV cluster.
+	fakeClient := newCNVClusterFakeClient("spoke01",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(mcvGR, "c1")
+		},
+	)
+	h := newFakeAuthHandlerWithMCV(t, upSrv, fakeClient, thanosSrv, searchSrv)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	req.Header.Set("Authorization", "Bearer cluster-admin-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
+// TestServeHTTP_RBAC_ClusterAdminDenied_MissingCluster verifies that a caller
+// whose managedcluster:admin does NOT cover all CNV clusters is denied.
+func TestServeHTTP_RBAC_ClusterAdminDenied_MissingCluster(t *testing.T) {
+	thanosSrv := newFakeThanosServer(t)
+	defer thanosSrv.Close()
+	searchSrv := newFakeSearchServer(t, []string{})
+	defer searchSrv.Close()
+
+	// managedcluster:admin covers only "spoke01", but "spoke02" also has CNV.
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleManagedClusterAdmin(): {"spoke01"},
+	})
+	defer upSrv.Close()
+
+	fakeClient := newCNVClusterFakeClient("spoke02")
+	h := newFakeAuthHandlerWithMCV(t, upSrv, fakeClient, thanosSrv, searchSrv)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	req.Header.Set("Authorization", "Bearer partial-admin-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestServeHTTP_RBAC_AuthServerError verifies that when the UserPermission
+// lookup fails with an unexpected error, ServeHTTP returns HTTP 500.
+func TestServeHTTP_RBAC_AuthServerError(t *testing.T) {
+	badAuth := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer badAuth.Close()
+
+	h := &Handler{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		RestConfig:    &rest.Config{Host: badAuth.URL},
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/migration-targets?cluster=c1&vmNamespace=ns&vmName=vm", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── userPermissionCoversHub unit tests ───────────────────────────────────────
+
+func TestUserPermissionCoversHub_LocalClusterBinding(t *testing.T) {
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleVMFleetAdmin(): {hubClusterName},
+	})
+	defer upSrv.Close()
+
+	dynClient, err := dynamic.NewForConfig(&rest.Config{Host: upSrv.URL})
+	require.NoError(t, err)
+
+	ok, err := userPermissionCoversHub(context.Background(), dynClient)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestUserPermissionCoversHub_NoLocalClusterBinding(t *testing.T) {
+	// acm-vm-fleet:admin exists but only for a spoke cluster.
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleVMFleetAdmin(): {"spoke01"},
+	})
+	defer upSrv.Close()
+
+	dynClient, err := dynamic.NewForConfig(&rest.Config{Host: upSrv.URL})
+	require.NoError(t, err)
+
+	ok, err := userPermissionCoversHub(context.Background(), dynClient)
+	require.NoError(t, err)
+	assert.False(t, ok, "spoke-only binding should not grant advisor access")
+}
+
+func TestUserPermissionCoversHub_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	dynClient, err := dynamic.NewForConfig(&rest.Config{Host: srv.URL})
+	require.NoError(t, err)
+
+	ok, err := userPermissionCoversHub(context.Background(), dynClient)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// ── callerIsClusterAdmin unit tests ──────────────────────────────────────────
+
+func TestCallerIsClusterAdmin_AllCNVClustersCovers(t *testing.T) {
+	// Controller sees "spoke01" as the CNV cluster.
+	controllerClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(),
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1",
+				"kind":       "ManagedCluster",
+				"metadata": map[string]interface{}{
+					"name":   "spoke01",
+					"labels": map[string]interface{}{cnvOperatorInstallLabel: "true"},
+				},
+			},
+		},
+	)
+
+	// Caller's managedcluster:admin covers "spoke01".
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleManagedClusterAdmin(): {"spoke01", hubClusterName},
+	})
+	defer upSrv.Close()
+
+	callerClient, err := dynamic.NewForConfig(&rest.Config{Host: upSrv.URL})
+	require.NoError(t, err)
+
+	ok, err := callerIsClusterAdmin(context.Background(), controllerClient, callerClient)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCallerIsClusterAdmin_MissingOneCluster(t *testing.T) {
+	// Controller sees "spoke01" and "spoke02".
+	controllerClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(),
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1",
+				"kind":       "ManagedCluster",
+				"metadata": map[string]interface{}{
+					"name":   "spoke01",
+					"labels": map[string]interface{}{cnvOperatorInstallLabel: "true"},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "cluster.open-cluster-management.io/v1",
+				"kind":       "ManagedCluster",
+				"metadata": map[string]interface{}{
+					"name":   "spoke02",
+					"labels": map[string]interface{}{cnvOperatorInstallLabel: "true"},
+				},
+			},
+		},
+	)
+
+	// Caller's managedcluster:admin covers only "spoke01" — missing "spoke02".
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleManagedClusterAdmin(): {"spoke01"},
+	})
+	defer upSrv.Close()
+
+	callerClient, err := dynamic.NewForConfig(&rest.Config{Host: upSrv.URL})
+	require.NoError(t, err)
+
+	ok, err := callerIsClusterAdmin(context.Background(), controllerClient, callerClient)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCallerIsClusterAdmin_NoCNVClusters(t *testing.T) {
+	// No CNV clusters → deny access.
+	// Seed with dummyManagedCluster so the fake knows the list type, then
+	// override with a reactor that returns an empty list.
+	controllerClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), dummyManagedCluster)
+	controllerClient.PrependReactor("list", "managedclusters",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   managedClusterGVR.Group,
+				Version: "v1",
+				Kind:    "ManagedClusterList",
+			})
+			return true, list, nil
+		},
+	)
+
+	upSrv := newFakeUserPermissionServer(t, map[string][]string{
+		advisorRoleManagedClusterAdmin(): {hubClusterName},
+	})
+	defer upSrv.Close()
+
+	callerClient, err := dynamic.NewForConfig(&rest.Config{Host: upSrv.URL})
+	require.NoError(t, err)
+
+	ok, err := callerIsClusterAdmin(context.Background(), controllerClient, callerClient)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// ── listCNVManagedClusters unit tests ────────────────────────────────────────
+
+func TestListCNVManagedClusters(t *testing.T) {
+	cnvCluster := &unstructured.Unstructured{}
+	cnvCluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   managedClusterGVR.Group,
+		Version: "v1",
+		Kind:    "ManagedCluster",
+	})
+	cnvCluster.SetName("spoke01")
+	cnvCluster.SetLabels(map[string]string{cnvOperatorInstallLabel: "true"})
+
+	nonCNV := &unstructured.Unstructured{}
+	nonCNV.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   managedClusterGVR.Group,
+		Version: "v1",
+		Kind:    "ManagedCluster",
+	})
+	nonCNV.SetName("spoke02")
+
+	fakeClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), cnvCluster, nonCNV, dummyManagedCluster)
+
+	// Override list to apply label filtering (fake client ignores LabelSelector).
+	fakeClient.PrependReactor("list", "managedclusters",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			listAction := action.(k8stesting.ListAction)
+			restriction := listAction.GetListRestrictions()
+			selector := restriction.Labels.String()
+
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   managedClusterGVR.Group,
+				Version: "v1",
+				Kind:    "ManagedClusterList",
+			})
+			if selector == cnvOperatorInstallLabel+"=true" {
+				list.Items = []unstructured.Unstructured{*cnvCluster}
+			}
+			return true, list, nil
+		},
+	)
+
+	clusters, err := listCNVManagedClusters(context.Background(), fakeClient)
+	require.NoError(t, err)
+	assert.Len(t, clusters, 1)
+	assert.Contains(t, clusters, "spoke01")
+	assert.NotContains(t, clusters, "spoke02")
+}

--- a/test/e2e/migration_advisor_test.go
+++ b/test/e2e/migration_advisor_test.go
@@ -24,10 +24,11 @@ import (
 
 var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, func() {
 	const (
-		path                = "../resources/migration_advisor"
-		managedclusterPath  = path + "/managedcluster.yaml"
-		targetClusterPath   = path + "/target_managedcluster.yaml"
-		untargetClusterPath = path + "/untarget_managecluster.yaml"
+		path                 = "../resources/migration_advisor"
+		managedclusterPath   = path + "/managedcluster.yaml"
+		targetClusterPath    = path + "/target_managedcluster.yaml"
+		untargetClusterPath  = path + "/untarget_managecluster.yaml"
+		userpermissionPath   = path + "/userpermission.yaml"
 
 		sourceCluster = "advisor-cluster"
 		vmNamespace   = "default"
@@ -190,8 +191,10 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 
 		authClient = &http.Client{
 			Transport: &bearerRoundTripper{token: tokenResp.Status.Token},
+			Timeout:   15 * time.Second,
 		}
 
+		utils.Kubectl("apply", "-f", userpermissionPath)
 		utils.Kubectl("apply", "-f", managedclusterPath)
 		utils.Kubectl("apply", "-f", targetClusterPath)
 		utils.Kubectl("apply", "-f", untargetClusterPath)
@@ -210,8 +213,13 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 
 	AfterAll(func() {
 		ctx := GinkgoT().Context()
-		_ = clientHub.RbacV1().ClusterRoleBindings().Delete(ctx, advisorSAName, metav1.DeleteOptions{})
-		_ = clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Delete(ctx, advisorSAName, metav1.DeleteOptions{})
+		if err := clientHub.RbacV1().ClusterRoleBindings().Delete(ctx, advisorSAName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		if err := clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Delete(ctx, advisorSAName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		utils.Kubectl("delete", "-f", userpermissionPath, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", managedclusterPath, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", targetClusterPath, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", untargetClusterPath, "--ignore-not-found")

--- a/test/e2e/migration_advisor_test.go
+++ b/test/e2e/migration_advisor_test.go
@@ -213,10 +213,12 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 
 	AfterAll(func() {
 		ctx := GinkgoT().Context()
-		if err := clientHub.RbacV1().ClusterRoleBindings().Delete(ctx, advisorSAName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		err := clientHub.RbacV1().ClusterRoleBindings().Delete(ctx, advisorSAName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
-		if err := clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Delete(ctx, advisorSAName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		err = clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Delete(ctx, advisorSAName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 		utils.Kubectl("delete", "-f", userpermissionPath, "--ignore-not-found")

--- a/test/e2e/migration_advisor_test.go
+++ b/test/e2e/migration_advisor_test.go
@@ -13,7 +13,9 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Ginkgo tests conventionally use dot imports.
 	. "github.com/onsi/gomega"    //nolint:revive // Gomega assertions are used pervasively in this file.
 	"github.com/stolostron/mtv-integrations/test/utils"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,7 +42,15 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 		Resource: "managedclusterviews",
 	}
 
-	var baseURL string
+	const (
+		advisorSAName      = "advisor-e2e-sa"
+		advisorSANamespace = "default"
+	)
+
+	var (
+		baseURL    string
+		authClient *http.Client // sends Authorization: Bearer <advisor-e2e-sa token>
+	)
 
 	ensureNamespace := func(ctx context.Context, name string) {
 		_, err := clientHub.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
@@ -141,6 +151,47 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 		baseURL = "http://127.0.0.1:8082"
 		ctx := GinkgoT().Context()
 
+		// Create a ServiceAccount and bind it to cluster-admin so its token
+		// passes the advisor RBAC gate. Kind uses cert auth for the admin
+		// kubeconfig, which adds no Authorization header — we need a real
+		// Bearer token to test the authenticated path.
+		_, err := clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Create(ctx,
+			&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: advisorSAName},
+			}, metav1.CreateOptions{})
+		if !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		_, err = clientHub.RbacV1().ClusterRoleBindings().Create(ctx,
+			&rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: advisorSAName},
+				Subjects: []rbacv1.Subject{{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      advisorSAName,
+					Namespace: advisorSANamespace,
+				}},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "cluster-admin",
+				},
+			}, metav1.CreateOptions{})
+		if !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		expiry := int64(3600)
+		tokenResp, err := clientHub.CoreV1().ServiceAccounts(advisorSANamespace).
+			CreateToken(ctx, advisorSAName, &authv1.TokenRequest{
+				Spec: authv1.TokenRequestSpec{ExpirationSeconds: &expiry},
+			}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		authClient = &http.Client{
+			Transport: &bearerRoundTripper{token: tokenResp.Status.Token},
+		}
+
 		utils.Kubectl("apply", "-f", managedclusterPath)
 		utils.Kubectl("apply", "-f", targetClusterPath)
 		utils.Kubectl("apply", "-f", untargetClusterPath)
@@ -158,6 +209,9 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 	})
 
 	AfterAll(func() {
+		ctx := GinkgoT().Context()
+		_ = clientHub.RbacV1().ClusterRoleBindings().Delete(ctx, advisorSAName, metav1.DeleteOptions{})
+		_ = clientHub.CoreV1().ServiceAccounts(advisorSANamespace).Delete(ctx, advisorSAName, metav1.DeleteOptions{})
 		utils.Kubectl("delete", "-f", managedclusterPath, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", targetClusterPath, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", untargetClusterPath, "--ignore-not-found")
@@ -173,8 +227,7 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 	})
 
 	It("returns 400 on /api/v1/migration-targets when required params are missing", func() {
-		// Deliberately call without required query params. A 400 confirms route is
-		// served end-to-end by the advisor API process.
+		// Params are validated before the auth check, so 400 is returned even without a token.
 		resp, err := http.Get(baseURL + "/api/v1/migration-targets")
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
@@ -182,10 +235,20 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 
-	It("returns 200 on /api/v1/migration-targets with fake Search and fake MCV", func() {
+	It("returns 401 on /api/v1/migration-targets when Authorization header is missing", func() {
 		url := fmt.Sprintf("%s/api/v1/migration-targets?vmNamespace=%s&vmName=%s&cluster=%s",
 			baseURL, vmNamespace, vmName, sourceCluster)
 		resp, err := http.Get(url)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("returns 200 on /api/v1/migration-targets with fake Search and fake MCV", func() {
+		url := fmt.Sprintf("%s/api/v1/migration-targets?vmNamespace=%s&vmName=%s&cluster=%s",
+			baseURL, vmNamespace, vmName, sourceCluster)
+		resp, err := authClient.Get(url)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 
@@ -222,3 +285,12 @@ var _ = Describe("Migration advisor API", Label("migration_advisor"), Ordered, f
 		Expect(foundUntarget).To(BeTrue(), "expected untarget-cluster in excludedClusters")
 	})
 })
+
+// bearerRoundTripper injects an Authorization: Bearer header on every request.
+type bearerRoundTripper struct{ token string }
+
+func (b *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := req.Clone(req.Context())
+	r.Header.Set("Authorization", "Bearer "+b.token)
+	return http.DefaultTransport.RoundTrip(r)
+}

--- a/test/resources/migration_advisor/userpermission.yaml
+++ b/test/resources/migration_advisor/userpermission.yaml
@@ -1,0 +1,12 @@
+# UserPermission fixture for migration-advisor e2e on kind.
+# kind/etcd reject ':' in resource names, so we use hyphen names and point the
+# controller at them via MTV_ADVISOR_ROLE_VM_FLEET_ADMIN env var.
+apiVersion: clusterview.open-cluster-management.io/v1alpha1
+kind: UserPermission
+metadata:
+  name: acm-vm-fleet-admin
+status:
+  bindings:
+    - cluster: local-cluster
+      namespaces:
+        - "*"


### PR DESCRIPTION
## Summary

- Restricts the `/api/v1/migration-targets` endpoint so only users holding `acm-vm-fleet:admin` (with a `local-cluster` binding) or `managedcluster:admin` covering **every** CNV-enabled managed cluster (`acm/cnv-operator-install=true`) can retrieve recommendations; all others receive HTTP 403.
- The check is performed by building a dynamic client from the caller's own Bearer token (not the controller SA), mirroring the impersonation pattern in `webhook/plan_webhook.go`.
- Role names default to production values (`acm-vm-fleet:admin`, `managedcluster:admin`) and are overridable via env vars (`MTV_ADVISOR_ROLE_VM_FLEET_ADMIN`, `MTV_ADVISOR_ROLE_CLUSTER_ADMIN`) for kind/e2e where `:` is rejected in resource names.

## Changes

| File | What |
|---|---|
| `controllers/migrationadvisor/rbac.go` | New: `checkCallerAuthorized`, `userPermissionCoversHub`, `callerIsClusterAdmin`, `listCNVManagedClusters` |
| `controllers/migrationadvisor/handler.go` | RBAC gate before evaluation; 401 for missing token, 403 for denied |
| `controllers/migrationadvisor/rbac_test.go` | Unit tests: allowed, denied, partial-admin, missing-token, server-error |
| `controllers/migrationadvisor/handler_test.go` | Update helpers to wire fake UserPermission server |
| `test/resources/migration_advisor/userpermission.yaml` | kind-safe UserPermission fixture (`acm-vm-fleet-admin`) |
| `test/e2e/migration_advisor_test.go` | SA Bearer token for auth; add 401 test; fix 200 test |
| `Makefile` | `run-advisor-test` applies fixture + exports DNS-safe role name env var |

## Test plan

- [ ] Unit tests: `go test ./controllers/migrationadvisor/...` — covers 401 (no token), 403 (denied), 403 (partial cluster-admin), 200 (fleet-admin), 200 (cluster-admin), 500 (auth server error)
- [ ] e2e: `make run-advisor-test` — covers 400 (missing params), 401 (no token), 200 (authorized SA)
- [ ] Lint: `golangci-lint run ./controllers/migrationadvisor/... ./test/e2e/...`

Resolves: https://redhat.atlassian.net/browse/ACM-34763

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration Advisor API now requires bearer-token authentication and enforces RBAC with two authorization paths; unauthenticated requests return 401, unauthorized requests return 403, and authorization errors return 500.

* **Tests**
  * End-to-end and unit tests updated to exercise the new auth/RBAC behavior using an authenticated service account and a new test permission fixture; test setup/teardown cleans up the fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->