### PR TITLE
docs(cnv): add CVE workflow rule and CLAUDE.md guidance (ACM-35013)

### DIFF
--- a/.cursor/rules/cnv-cve-workflow.mdc
+++ b/.cursor/rules/cnv-cve-workflow.mdc
@@ -29,4 +29,4 @@ When a vulnerability (CVE) is resolved in [`stolostron/mtv-integrations`](https:
 
 - Use MCP Jira tools (`get_issue`, `update_issue`, `add_comment`, `transition_issue`) to manage tickets directly.
 - After assigning to `ocp-sustaining-admins`, transition the ticket to **Done** only when all acceptance criteria are met.
-- If no CVE tickets exist yet, note that in the ticket comment and close ACM-35013.
+- If no CVE tickets exist yet, add a comment to **ACM-35013** documenting that no open vulnerability tickets were found, then transition ACM-35013 to **Done**.

--- a/.cursor/rules/cnv-cve-workflow.mdc
+++ b/.cursor/rules/cnv-cve-workflow.mdc
@@ -1,0 +1,32 @@
+---
+description: CVE workflow for the Container Native Virtualization (CNV) component — how to handle vulnerability tickets after a fix lands on main
+alwaysApply: true
+---
+
+# CNV CVE Workflow (ACM-35013)
+
+When a vulnerability (CVE) is resolved in [`stolostron/mtv-integrations`](https://github.com/stolostron/mtv-integrations), follow this process:
+
+## Three-step workflow
+
+1. **Verify fix on main** — confirm the PR is merged and CI is green on `main`.
+2. **Assign to sustaining** — update the Jira vulnerability ticket: set assignee to **`ocp-sustaining-admins`**.
+3. **Comment on the ticket** with:
+   - PR link(s) that resolved the issue on `main`
+   - Any backport context (breaking changes, deps, affected versions)
+
+## Scope
+
+| Item | Value |
+|------|-------|
+| Component | Container Native Virtualization |
+| Repo | [`stolostron/mtv-integrations`](https://github.com/stolostron/mtv-integrations) |
+| Sustaining team | `ocp-sustaining-admins` |
+| Parent ticket | ACM-27405 (Sustaining Engineering transition) |
+| Jira project | ACM |
+
+## When helping with CVE tasks
+
+- Use MCP Jira tools (`get_issue`, `update_issue`, `add_comment`, `transition_issue`) to manage tickets directly.
+- After assigning to `ocp-sustaining-admins`, transition the ticket to **Done** only when all acceptance criteria are met.
+- If no CVE tickets exist yet, note that in the ticket comment and close ACM-35013.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ Use the tool-aware fallback chain: ~/.config/opencode/user.local.md (OpenCode),
 If none exist, fall back to agent memory (`user-config`), then placeholders.
 Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
 
+## CVE workflow — Container Native Virtualization (ACM-35013)
+
+When a CVE fix merges on `main` in [`stolostron/mtv-integrations`](https://github.com/stolostron/mtv-integrations):
+
+1. Confirm the fix is merged and CI passes on `main`.
+2. Assign the Jira vulnerability ticket to **`ocp-sustaining-admins`**.
+3. Comment on the ticket: PR link(s), backport context, affected versions.
+
+Use MCP Jira tools for ticket operations. Parent: ACM-27405.
+
 ## Fleet Engineering Skills
 
 All skills are available as slash commands via the installed Fleet Engineering plugin. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.


### PR DESCRIPTION
## Summary

- Adds `.cursor/rules/cnv-cve-workflow.mdc` (always-apply Cursor rule) documenting the three-step CVE triage workflow for the `stolostron/mtv-integrations` CNV component: verify fix on main → assign to `ocp-sustaining-admins` → comment with PR link and backport context.
- Adds a concise CVE workflow section to `CLAUDE.md` for Claude Code sessions.

## Context

Part of the Sustaining Engineering transition ([ACM-27405](https://redhat.atlassian.net/browse/ACM-27405)). The Container Native Virtualization component team needs a documented workflow so CVE vulnerability tickets are consistently handed off to `ocp-sustaining-admins` after a fix lands on `main`.

## Test plan

- [ ] Rule file loads correctly in Cursor (check `.cursor/rules/cnv-cve-workflow.mdc` appears in rule picker)
- [ ] CLAUDE.md section is visible and accurate

Resolves: https://redhat.atlassian.net/browse/ACM-35013

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CVE workflow guidelines covering vulnerability fix verification, ticket management, and communication procedures for container native virtualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-27405]: https://redhat.atlassian.net/browse/ACM-27405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ