### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV BUILD_TAGS="strictfipsruntime"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/mtv-integrations
 
-go 1.25.2
+go 1.26.0
 
 require (
 	github.com/kubev2v/forklift v0.0.0-20260511180337-abefdf391aaf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go toolchain version from 1.25.2 to 1.26.0.
  * Updated container build stages to use Go 1.26 builder images across all build configurations.
  * Kept runtime behavior and application code changes unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->