### PR TITLE
chore: upgrade Go toolchain from 1.25 to 1.26 (ACM-35534)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV BUILD_TAGS="strictfipsruntime"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/mtv-integrations
 
-go 1.25.2
+go 1.26
 
 require (
 	github.com/kubev2v/forklift v0.0.0-20260511180337-abefdf391aaf


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` from `1.25.2` to `1.26` and runs `go mod tidy`
- Updates builder base images in all three Dockerfiles (`go1.25-linux` → `go1.26-linux`, `rhel_9_1.25` → `rhel_9_1.26`)
- GitHub Actions CI workflows already use `go-version-file: go.mod` so they pick up 1.26 automatically — no workflow changes needed

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` (unit, excluding e2e which requires a kind cluster) — all pass

Resolves: https://redhat.atlassian.net/browse/ACM-35534

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated Go runtime version to 1.26 across Docker build configurations and project toolchain settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->