### PR TITLE
fix(advisor): use plain HTTP for in-cluster Thanos default endpoint

### DIFF
--- a/controllers/migrationadvisor/observability_client.go
+++ b/controllers/migrationadvisor/observability_client.go
@@ -20,7 +20,8 @@ import (
 
 const (
 	// thanosQueryFrontend is the in-cluster Thanos Query Frontend from MCO.
-	thanosQueryFrontend = "https://observability-thanos-query-frontend.open-cluster-management-observability.svc:9090"
+	// Port 9090 is plain HTTP; TLS is only used for the external rbac-query-proxy Route.
+	thanosQueryFrontend = "http://observability-thanos-query-frontend.open-cluster-management-observability.svc:9090"
 
 	// promStatusSuccess is the expected status value in a successful Prometheus API response.
 	promStatusSuccess = "success"


### PR DESCRIPTION
## Summary

- The in-cluster `observability-thanos-query-frontend` service on port 9090 serves plain HTTP, not HTTPS
- The hardcoded default constant was set to `https://` which caused `http: server gave HTTP response to HTTPS client` errors when the external `rbac-query-proxy` Route auto-discovery fell back to the in-cluster default
- This resulted in a `500 Internal Server Error` from the `/api/v1/migration-targets` endpoint
- Fix: change the fallback default scheme to `http://`; TLS is only used when connecting via the external `rbac-query-proxy` Route discovered at startup

## Test plan

- [ ] Deploy the fix and call `GET /api/v1/migration-targets?cluster=<hosting-cluster>&vmName=<vm>&vmNamespace=<ns>` — confirmed 200 with recommendation response in dev cluster
- [ ] Verify that when `rbac-query-proxy` Route is available, the auto-discovered `https://` Route endpoint still works (unchanged code path)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an internal observability service configuration issue that affects system monitoring connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->