### PR TITLE
fix(plan): set blockOwnerDeletion=false to avoid finalizers RBAC error

### DIFF
--- a/controllers/plan/plan_controller.go
+++ b/controllers/plan/plan_controller.go
@@ -183,7 +183,7 @@ func (r *PlanReconciler) setOwner(ctx context.Context, plan, obj *unstructured.U
 	obj.SetOwnerReferences(filtered)
 
 	isController := true
-	blockOwnerDeletion := false // requires finalizers RBAC we don't have; GC still cascades
+	blockOwnerDeletion := false
 	obj.SetOwnerReferences(append(obj.GetOwnerReferences(), metav1.OwnerReference{
 		APIVersion:         planGVK.Group + "/" + planGVK.Version,
 		Kind:               planGVK.Kind,

--- a/controllers/plan/plan_controller.go
+++ b/controllers/plan/plan_controller.go
@@ -183,7 +183,7 @@ func (r *PlanReconciler) setOwner(ctx context.Context, plan, obj *unstructured.U
 	obj.SetOwnerReferences(filtered)
 
 	isController := true
-	blockOwnerDeletion := true
+	blockOwnerDeletion := false // requires finalizers RBAC we don't have; GC still cascades
 	obj.SetOwnerReferences(append(obj.GetOwnerReferences(), metav1.OwnerReference{
 		APIVersion:         planGVK.Group + "/" + planGVK.Version,
 		Kind:               planGVK.Kind,


### PR DESCRIPTION
## Summary

- The plan reconciler was crashing-looping trying to stamp `OwnerReference` on `NetworkMap` and `StorageMap` resources, but every attempt was rejected by the API server.
- Root cause: `blockOwnerDeletion: true` requires the service account to have `update` on the `networkmaps/finalizers` and `storagemaps/finalizers` subresources, which the mtv-integrations ClusterRole does not grant.
- Fix: set `blockOwnerDeletion: false` — the Kubernetes GC still cascade-deletes the maps when the Plan is deleted; we just no longer block the Plan's own deletion until the maps are gone (which was never a requirement).

## Error seen in logs

```
networkmaps.forklift.konveyor.io "cross-cluster-migration-vyl1gm-ixkxjn" is forbidden:
cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```

## Test plan

- [x] All existing unit tests pass (`go test ./controllers/plan/...`)
- [x] No ClusterRole changes required
- [ ] Deploy to a cluster and confirm the `OwnerReference` is stamped on `NetworkMap`/`StorageMap` without errors

Made with [Cursor](https://cursor.com)