### PR TITLE
fix(charts): add pre-delete hook to clear MRA finalizer on uninstall (ACM-37259)

### DIFF
--- a/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
+++ b/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
@@ -76,6 +76,8 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  backoffLimit: 4
+  activeDeadlineSeconds: 120
   ttlSecondsAfterFinished: 300
   template:
     metadata:

--- a/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
+++ b/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
@@ -1,0 +1,122 @@
+---
+# Pre-delete hook: strip the finalizer from the mtv-advisor-storageclasses
+# MulticlusterRoleAssignment so that MCH uninstallation does not hang.
+#
+# Problem: MCH tears down all Helm releases (including the
+# multicluster-role-assignment controller) before deleting the template
+# resources it manages.  Once that controller is gone, no one can remove
+# the finalizer "finalizer.rbac.open-cluster-management.io/
+# multiclusterroleassignment", leaving the resource stuck in Terminating
+# and the MCH uninstall loop waiting forever.
+#
+# Solution: run this Job during "helm uninstall" (pre-delete hook), before
+# any chart resources are deleted and while the cluster API is still healthy.
+# The Job force-clears the finalizer and deletes the MRA, regardless of
+# whether the MRA controller is still running.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mtv-advisor-mra-cleanup
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mtv-advisor-mra-cleanup
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - rbac.open-cluster-management.io
+  resources:
+  - multiclusterroleassignments
+  verbs:
+  - get
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mtv-advisor-mra-cleanup
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mtv-advisor-mra-cleanup
+subjects:
+- kind: ServiceAccount
+  name: mtv-advisor-mra-cleanup
+  namespace: {{ .Values.global.namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mtv-advisor-mra-cleanup
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mtv-integrations
+    spec:
+      serviceAccountName: mtv-advisor-mra-cleanup
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+        - {{ if .Key }}key: {{ .Key }}{{ end }}
+          {{ if .Operator }}operator: {{ .Operator }}{{ end }}
+          {{ if .Value }}value: {{ .Value }}{{ end }}
+          {{ if .Effect }}effect: {{ .Effect }}{{ end }}
+          {{ if .TolerationSeconds }}tolerationSeconds: {{ .TolerationSeconds }}{{ end }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: cleanup
+        image: {{ .Values.global.imageOverrides.mtv_integrations }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - /manager
+        - cleanup
+        - --namespace={{ .Values.global.namespace }}
+      {{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret }}
+      {{- end }}

--- a/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
+++ b/charts/templates/mtv-advisor-mra-cleanup-hook.yaml
@@ -42,7 +42,7 @@ rules:
   - multiclusterroleassignments
   verbs:
   - get
-  - patch
+  - update
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,7 +373,90 @@ func setupTLSProfileWatcher(mgr ctrl.Manager, cancel context.CancelFunc, profile
 	}).SetupWithManager(mgr)
 }
 
+// mraGVR is the GroupVersionResource for MulticlusterRoleAssignment.
+var mraGVR = schema.GroupVersionResource{
+	Group:    "rbac.open-cluster-management.io",
+	Version:  "v1beta1",
+	Resource: "multiclusterroleassignments",
+}
+
+// runCleanup is the handler for the "cleanup" subcommand.  It is invoked by
+// the Helm pre-delete hook Job (cmd/main.go cleanup --namespace=<ns>) to
+// strip the finalizer from the mtv-advisor-storageclasses
+// MulticlusterRoleAssignment and delete it before the Helm release is torn
+// down.  Using the manager binary avoids a second container image dependency
+// (no ose-cli / kubectl image required) and ensures MCH can pin the image
+// digest like every other component image.
+func runCleanup() {
+	fs := flag.NewFlagSet("cleanup", flag.ExitOnError)
+	namespace := fs.String("namespace", "open-cluster-management",
+		"Namespace of the MulticlusterRoleAssignment to clean up")
+	name := fs.String("name", "mtv-advisor-storageclasses",
+		"Name of the MulticlusterRoleAssignment to clean up")
+	_ = fs.Parse(os.Args[2:])
+
+	ctrl.SetLogger(zap.New())
+	log := ctrl.Log.WithName("cleanup")
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error(err, "failed to get cluster config")
+		os.Exit(1)
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.Error(err, "failed to create dynamic client")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	existing, err := dynClient.Resource(mraGVR).Namespace(*namespace).Get(ctx, *name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("MulticlusterRoleAssignment not found, nothing to clean up",
+				"name", *name, "namespace", *namespace)
+			return
+		}
+		if meta.IsNoMatchError(err) {
+			log.Info("MulticlusterRoleAssignment CRD not present, nothing to clean up")
+			return
+		}
+		log.Error(err, "failed to get MulticlusterRoleAssignment",
+			"name", *name, "namespace", *namespace)
+		os.Exit(1)
+	}
+
+	existing.SetFinalizers(nil)
+	if _, err = dynClient.Resource(mraGVR).Namespace(*namespace).Update(
+		ctx, existing, metav1.UpdateOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "failed to remove finalizers from MulticlusterRoleAssignment",
+			"name", *name, "namespace", *namespace)
+		os.Exit(1)
+	}
+	log.Info("Removed finalizers from MulticlusterRoleAssignment",
+		"name", *name, "namespace", *namespace)
+
+	if err = dynClient.Resource(mraGVR).Namespace(*namespace).Delete(
+		ctx, *name, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "failed to delete MulticlusterRoleAssignment",
+			"name", *name, "namespace", *namespace)
+		os.Exit(1)
+	}
+	log.Info("MulticlusterRoleAssignment deleted", "name", *name, "namespace", *namespace)
+}
+
 func main() {
+	// Route to the cleanup subcommand before any flag parsing so the heavy
+	// manager setup is completely bypassed.
+	if len(os.Args) > 1 && os.Args[1] == "cleanup" {
+		runCleanup()
+		return
+	}
+
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string


### PR DESCRIPTION
## Summary

Fixes sporadically stuck MCH uninstallation caused by the `mtv-advisor-storageclasses` `MulticlusterRoleAssignment` never finishing deletion.

**Root cause** (identified in [multicluster-role-assignment#381](https://github.com/stolostron/multicluster-role-assignment/pull/381)): the MRA controller used `GenerationChangedPredicate`, which silently drops the Delete event because setting `DeletionTimestamp` is a metadata-only change (generation does not increment). The primary fix is in that repo.

**Defensive fix here**: during MCH uninstallation all HelmReleases are terminated before MCH deletes template resources. If the MRA controller is gone by the time `mtv-advisor-storageclasses` is deleted, its finalizer (`finalizer.rbac.open-cluster-management.io/multiclusterroleassignment`) can never be removed and the MCH uninstall loop hangs indefinitely.

## Changes

- **`charts/templates/mtv-advisor-mra-cleanup-hook.yaml`** (new): Helm `pre-delete` hook that runs before any chart resources are deleted:
  - Scoped `ServiceAccount` + `ClusterRole` + `ClusterRoleBinding` (weight -10)
  - `Job` (weight -5) that updates `finalizers: null` on `mtv-advisor-storageclasses` then deletes the MRA; gracefully no-ops if the CRD or resource is already gone
  - `backoffLimit: 4` and `activeDeadlineSeconds: 120` to prevent an unbounded stall if the Job fails
- **`cmd/main.go`**: adds a `cleanup` subcommand (`/manager cleanup --namespace=<ns>`) that performs the finalizer removal and deletion using the dynamic client, reusing the existing manager binary image (no separate `ose-cli` / `kubectl` image needed)

## Test plan

- [ ] Install ACM with CNV-MTV enabled
- [ ] Delete MCH — uninstallation completes without hanging on `MulticlusterRoleAssignment mtv-advisor-storageclasses`
- [ ] Verify the cleanup hook Job runs and exits 0 (check `kubectl logs -n open-cluster-management job/mtv-advisor-mra-cleanup`)
- [ ] Confirm no orphaned `MulticlusterRoleAssignment`, `ClusterRole`, or `ClusterRoleBinding` `mtv-advisor-mra-cleanup` remain after uninstall

Fixes: ACM-37259