### PR TITLE
fix(cnv-addon): translate HyperConverged spec to v1 API structure (ACM-30004)

### DIFF
--- a/addons/cnv-addon/cnv-addon-template.yaml
+++ b/addons/cnv-addon/cnv-addon-template.yaml
@@ -33,57 +33,58 @@ spec:
           kind: HyperConverged
           metadata:
             name: kubevirt-hyperconverged
+            namespace: openshift-cnv
             annotations:
               deployOVS: 'false'
-            namespace: openshift-cnv
           spec:
-            virtualMachineOptions:
-              disableFreePageReporting: false
-              disableSerialConsoleLog: true
-            higherWorkloadDensity:
-              memoryOvercommitPercentage: 100
-            liveMigrationConfig:
-              allowAutoConverge: false
-              allowPostCopy: false
-              completionTimeoutPerGiB: 800
-              parallelMigrationsPerCluster: 5
-              parallelOutboundMigrationsPerNode: 2
-              progressTimeout: 150
-            certConfig:
-              ca:
-                duration: 48h0m0s
-                renewBefore: 24h0m0s
-              server:
-                duration: 24h0m0s
-                renewBefore: 12h0m0s
-            applicationAwareConfig:
-              allowApplicationAwareClusterResourceQuota: false
-              vmiCalcConfigName: DedicatedVirtualResources
-            featureGates:
-              decentralizedLiveMigration: true
-              deployTektonTaskResources: false
-              enableCommonBootImageImport: true
-              withHostPassthroughCPU: false
-              downwardMetrics: false
-              disableMDevConfiguration: false
-              enableApplicationAwareQuota: false
-              deployKubeSecondaryDNS: false
-              nonRoot: true
-              alignCPUs: false
-              enableManagedTenantQuota: false
-              primaryUserDefinedNetworkBinding: false
+            deployment:
+              applicationAwareConfig:
+                enable: false
+                vmiCalcConfigName: DedicatedVirtualResources
               deployVmConsoleProxy: false
-              persistentReservation: false
-              autoResourceLimits: false
-              deployKubevirtIpamController: false
-            workloadUpdateStrategy:
-              batchEvictionInterval: 1m0s
-              batchEvictionSize: 10
-              workloadUpdateMethods:
-                - LiveMigrate
-            uninstallStrategy: BlockUninstallIfWorkloadsExist
-            resourceRequirements:
+              uninstallStrategy: BlockUninstallIfWorkloadsExist
+            security:
+              certConfig:
+                ca:
+                  duration: 48h0m0s
+                  renewBefore: 24h0m0s
+                server:
+                  duration: 24h0m0s
+                  renewBefore: 12h0m0s
+            virtualization:
+              virtualMachineOptions:
+                disableFreePageReporting: false
+                disableSerialConsoleLog: true
+              higherWorkloadDensity:
+                memoryOvercommitPercentage: 100
+              liveMigrationConfig:
+                allowAutoConverge: false
+                allowPostCopy: false
+                completionTimeoutPerGiB: 800
+                parallelMigrationsPerCluster: 5
+                parallelOutboundMigrationsPerNode: 2
+                progressTimeout: 150
+              workloadUpdateStrategy:
+                batchEvictionInterval: 1m0s
+                batchEvictionSize: 10
+                workloadUpdateMethods:
+                  - LiveMigrate
               vmiCPUAllocationRatio: 10
+            featureGates:
+              - name: decentralizedLiveMigration
+                state: Enabled
+              - name: downwardMetrics
+                state: Disabled
+              - name: disableMDevConfiguration
+                state: Disabled
+              - name: deployKubeSecondaryDNS
+                state: Disabled
+              - name: alignCPUs
+                state: Disabled
+              - name: persistentReservation
+                state: Disabled
+            workloadSources:
+              enableCommonBootImageImport: true
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:

--- a/charts/templates/cnv-addon-template.yaml
+++ b/charts/templates/cnv-addon-template.yaml
@@ -86,54 +86,55 @@ spec:
           kind: HyperConverged
           metadata:
             name: kubevirt-hyperconverged
+            namespace: openshift-cnv
             annotations:
               deployOVS: 'false'
-            namespace: openshift-cnv
           spec:
-            virtualMachineOptions:
-              disableFreePageReporting: false
-              disableSerialConsoleLog: true
-            higherWorkloadDensity:
-              memoryOvercommitPercentage: 100
-            liveMigrationConfig:
-              allowAutoConverge: false
-              allowPostCopy: false
-              completionTimeoutPerGiB: 800
-              parallelMigrationsPerCluster: 5
-              parallelOutboundMigrationsPerNode: 2
-              progressTimeout: 150
-            certConfig:
-              ca:
-                duration: 48h0m0s
-                renewBefore: 24h0m0s
-              server:
-                duration: 24h0m0s
-                renewBefore: 12h0m0s
-            applicationAwareConfig:
-              allowApplicationAwareClusterResourceQuota: false
-              vmiCalcConfigName: DedicatedVirtualResources
-            featureGates:
-              decentralizedLiveMigration: true
-              deployTektonTaskResources: false
-              enableCommonBootImageImport: true
-              withHostPassthroughCPU: false
-              downwardMetrics: false
-              disableMDevConfiguration: false
-              enableApplicationAwareQuota: false
-              deployKubeSecondaryDNS: false
-              nonRoot: true
-              alignCPUs: false
-              enableManagedTenantQuota: false
-              primaryUserDefinedNetworkBinding: false
+            deployment:
+              applicationAwareConfig:
+                enable: false
+                vmiCalcConfigName: DedicatedVirtualResources
               deployVmConsoleProxy: false
-              persistentReservation: false
-              autoResourceLimits: false
-              deployKubevirtIpamController: false
-            workloadUpdateStrategy:
-              batchEvictionInterval: 1m0s
-              batchEvictionSize: 10
-              workloadUpdateMethods:
-                - LiveMigrate
-            uninstallStrategy: BlockUninstallIfWorkloadsExist
-            resourceRequirements:
+              uninstallStrategy: BlockUninstallIfWorkloadsExist
+            security:
+              certConfig:
+                ca:
+                  duration: 48h0m0s
+                  renewBefore: 24h0m0s
+                server:
+                  duration: 24h0m0s
+                  renewBefore: 12h0m0s
+            virtualization:
+              virtualMachineOptions:
+                disableFreePageReporting: false
+                disableSerialConsoleLog: true
+              higherWorkloadDensity:
+                memoryOvercommitPercentage: 100
+              liveMigrationConfig:
+                allowAutoConverge: false
+                allowPostCopy: false
+                completionTimeoutPerGiB: 800
+                parallelMigrationsPerCluster: 5
+                parallelOutboundMigrationsPerNode: 2
+                progressTimeout: 150
+              workloadUpdateStrategy:
+                batchEvictionInterval: 1m0s
+                batchEvictionSize: 10
+                workloadUpdateMethods:
+                  - LiveMigrate
               vmiCPUAllocationRatio: 10
+            featureGates:
+              - name: decentralizedLiveMigration
+                state: Enabled
+              - name: downwardMetrics
+                state: Disabled
+              - name: disableMDevConfiguration
+                state: Disabled
+              - name: deployKubeSecondaryDNS
+                state: Disabled
+              - name: alignCPUs
+                state: Disabled
+              - name: persistentReservation
+                state: Disabled
+            workloadSources:
+              enableCommonBootImageImport: true

--- a/update_cleanup.sh
+++ b/update_cleanup.sh
@@ -127,57 +127,58 @@ spec:
       kind: HyperConverged
       metadata:
         name: kubevirt-hyperconverged
+        namespace: openshift-cnv
         annotations:
           deployOVS: "false"
-        namespace: openshift-cnv
       spec:
-        virtualMachineOptions:
-          disableFreePageReporting: false
-          disableSerialConsoleLog: true
-        higherWorkloadDensity:
-          memoryOvercommitPercentage: 100
-        liveMigrationConfig:
-          allowAutoConverge: false
-          allowPostCopy: false
-          completionTimeoutPerGiB: 800
-          parallelMigrationsPerCluster: 5
-          parallelOutboundMigrationsPerNode: 2
-          progressTimeout: 150
-        certConfig:
-          ca:
-            duration: 48h0m0s
-            renewBefore: 24h0m0s
-          server:
-            duration: 24h0m0s
-            renewBefore: 12h0m0s
-        applicationAwareConfig:
-          allowApplicationAwareClusterResourceQuota: false
-          vmiCalcConfigName: DedicatedVirtualResources
-        featureGates:
-          decentralizedLiveMigration: true
-          deployTektonTaskResources: false
-          enableCommonBootImageImport: true
-          withHostPassthroughCPU: false
-          downwardMetrics: false
-          disableMDevConfiguration: false
-          enableApplicationAwareQuota: false
-          deployKubeSecondaryDNS: false
-          nonRoot: true
-          alignCPUs: false
-          enableManagedTenantQuota: false
-          primaryUserDefinedNetworkBinding: false
+        deployment:
+          applicationAwareConfig:
+            enable: false
+            vmiCalcConfigName: DedicatedVirtualResources
           deployVmConsoleProxy: false
-          persistentReservation: false
-          autoResourceLimits: false
-          deployKubevirtIpamController: false
-        workloadUpdateStrategy:
-          batchEvictionInterval: 1m0s
-          batchEvictionSize: 10
-          workloadUpdateMethods:
-          - LiveMigrate
-        uninstallStrategy: BlockUninstallIfWorkloadsExist
-        resourceRequirements:
+          uninstallStrategy: BlockUninstallIfWorkloadsExist
+        security:
+          certConfig:
+            ca:
+              duration: 48h0m0s
+              renewBefore: 24h0m0s
+            server:
+              duration: 24h0m0s
+              renewBefore: 12h0m0s
+        virtualization:
+          virtualMachineOptions:
+            disableFreePageReporting: false
+            disableSerialConsoleLog: true
+          higherWorkloadDensity:
+            memoryOvercommitPercentage: 100
+          liveMigrationConfig:
+            allowAutoConverge: false
+            allowPostCopy: false
+            completionTimeoutPerGiB: 800
+            parallelMigrationsPerCluster: 5
+            parallelOutboundMigrationsPerNode: 2
+            progressTimeout: 150
+          workloadUpdateStrategy:
+            batchEvictionInterval: 1m0s
+            batchEvictionSize: 10
+            workloadUpdateMethods:
+            - LiveMigrate
           vmiCPUAllocationRatio: 10
+        featureGates:
+        - name: decentralizedLiveMigration
+          state: Enabled
+        - name: downwardMetrics
+          state: Disabled
+        - name: disableMDevConfiguration
+          state: Disabled
+        - name: deployKubeSecondaryDNS
+          state: Disabled
+        - name: alignCPUs
+          state: Disabled
+        - name: persistentReservation
+          state: Disabled
+        workloadSources:
+          enableCommonBootImageImport: true
 EOF
   echo "Applied ManifestWork for cluster: ${cluster}"
 


### PR DESCRIPTION
## Summary

- **Use `hco.kubevirt.io/v1`** for the `HyperConverged` CR in the ManifestWork — the v1 API is the current stable version (v1beta1 is deprecated).
- **Translate all spec fields to the v1 schema** — the v1 API reorganises fields into named groups instead of flat top-level fields:

  | v1beta1 location | v1 location |
  |---|---|
  | `spec.liveMigrationConfig` | `spec.virtualization.liveMigrationConfig` |
  | `spec.virtualMachineOptions` | `spec.virtualization.virtualMachineOptions` |
  | `spec.higherWorkloadDensity` | `spec.virtualization.higherWorkloadDensity` |
  | `spec.workloadUpdateStrategy` | `spec.virtualization.workloadUpdateStrategy` |
  | `spec.resourceRequirements.vmiCPUAllocationRatio` | `spec.virtualization.vmiCPUAllocationRatio` |
  | `spec.certConfig` | `spec.security.certConfig` |
  | `spec.applicationAwareConfig` | `spec.deployment.applicationAwareConfig` |
  | `spec.uninstallStrategy` | `spec.deployment.uninstallStrategy` |
  | `spec.featureGates.deployVmConsoleProxy` (bool) | `spec.deployment.deployVmConsoleProxy` |
  | `spec.featureGates.enableCommonBootImageImport` (bool) | `spec.workloadSources.enableCommonBootImageImport` |
  | `spec.featureGates` (map of bools) | `spec.featureGates` (list of `{name, state}`) |

- **Drop graduated/removed feature gates** — `nonRoot`, `withHostPassthroughCPU`, `enableManagedTenantQuota`, `primaryUserDefinedNetworkBinding`, `autoResourceLimits`, `deployKubevirtIpamController`, `deployTektonTaskResources` no longer exist in the v1 schema.
- Apply the same corrections to `update_cleanup.sh` (manual recovery script).

## Test plan

- [x] Applied full v1 spec via `oc apply` on a live cluster — `ReconcileComplete=True`, `Available=True`, `Degraded=False`
- [x] Confirmed `liveMigrationConfig` (`completionTimeoutPerGiB: 800`, etc.) is picked up correctly from the v1 spec
- [ ] Apply the addon to a managed cluster with CNV installed and verify the `HyperConverged` CR is created with `v1`
- [ ] Run `update_cleanup.sh` on a cluster and confirm it applies without apiVersion errors

Jira: https://issues.redhat.com/browse/ACM-30004