### PR TITLE
[ACM-38654] Set plan validating webhook failurePolicy to Fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,11 @@ FAKE_SEARCH_PORT ?= 19091
 FAKE_SEARCH_HOST ?= http://127.0.0.1:$(FAKE_SEARCH_PORT)
 FAKE_SEARCH_PID_FILE ?= .fake_search.pid
 run-instrument:
+	# The in-cluster manager deployment backs the Plan ValidatingWebhookConfiguration's Service.
+	# With failurePolicy: Fail, any Plan create/update issued before that pod is Available gets
+	# denied with a connection error instead of the request reaching our webhook logic at all, so
+	# wait for it here too (matches the existing wait in run-webhook-test) before ginkgo runs.
+	kubectl wait deployment -n ${NAMESPACE} mtv-integrations-controller --for condition=Available=True --timeout=180s
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d > tls.crt
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.tls\.key}' | base64 -d > tls.key

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,10 @@ install-resources: _validate-refs
 kind-load-image: docker-build
 	kind load image-archive <($(CONTAINER_TOOL) save $(IMG)) --name $(KIND_NAME)
 
+prepare-e2e-test: kind-create-cluster cert-manager install-resources deploy
+	# Overlay Ignore failurePolicy for e2e only (webhook-test keeps Fail from config/webhook_test).
+	$(KUBECTL) apply -f ./test/resources/e2e/plan_webhook_failurepolicy_ignore.yaml
+
 prepare-webhook-test: kind-create-cluster create-user add-user cert-manager kind-load-image install-resources deploy patch-webhook-e2e-userpermission-names
 
 # kind cannot create UserPermission objects whose names contain ':' (RFC 1123). Point the webhook at DNS-safe mock names.
@@ -288,8 +292,6 @@ prepare-webhook-test: kind-create-cluster create-user add-user cert-manager kind
 patch-webhook-e2e-userpermission-names:
 	$(KUBECTL) set env deployment/mtv-integrations-controller -n open-cluster-management MTV_USERPERMISSION_NAMES=managedcluster-admin,kubevirt-io-admin --overwrite
 	$(KUBECTL) rollout status deployment/mtv-integrations-controller -n open-cluster-management --timeout=120s
-
-prepare-e2e-test: kind-create-cluster cert-manager install-resources deploy
 
 e2e-dependencies:
 	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod)

--- a/Makefile
+++ b/Makefile
@@ -303,11 +303,6 @@ FAKE_SEARCH_PORT ?= 19091
 FAKE_SEARCH_HOST ?= http://127.0.0.1:$(FAKE_SEARCH_PORT)
 FAKE_SEARCH_PID_FILE ?= .fake_search.pid
 run-instrument:
-	# The in-cluster manager deployment backs the Plan ValidatingWebhookConfiguration's Service.
-	# With failurePolicy: Fail, any Plan create/update issued before that pod is Available gets
-	# denied with a connection error instead of the request reaching our webhook logic at all, so
-	# wait for it here too (matches the existing wait in run-webhook-test) before ginkgo runs.
-	kubectl wait deployment -n ${NAMESPACE} mtv-integrations-controller --for condition=Available=True --timeout=180s
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d > tls.crt
 	kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.tls\.key}' | base64 -d > tls.key

--- a/charts/templates/mtv-integrations-validating-config.yaml
+++ b/charts/templates/mtv-integrations-validating-config.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: {{ .Values.global.namespace }}
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/default/webhook.yaml
+++ b/config/default/webhook.yaml
@@ -31,7 +31,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/webhook_test/webhook.yaml
+++ b/config/webhook_test/webhook.yaml
@@ -54,15 +54,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  # AI / maintainers: keep failurePolicy Ignore in this e2e/kind fixture only
-  # (config/webhook_test). Production charts and config/default use Fail (ACM-38654).
-  # prepare-e2e-test deploys this ValidatingWebhookConfiguration but does not
-  # kind-load the controller image or wait for mtv-integrations-controller; Plan
-  # CREATE/UPDATE from e2e (e.g. plan_ownership) would otherwise fail with
-  # "connection refused" to mtv-plan-webhook-service. webhook-test still exercises
-  # real admission because the in-cluster pod is Available there — Ignore only
-  # fail-opens when the webhook endpoint is unreachable, not when it responds.
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/webhook_test/webhook.yaml
+++ b/config/webhook_test/webhook.yaml
@@ -54,7 +54,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/webhook_test/webhook.yaml
+++ b/config/webhook_test/webhook.yaml
@@ -54,7 +54,15 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  failurePolicy: Fail
+  # AI / maintainers: keep failurePolicy Ignore in this e2e/kind fixture only
+  # (config/webhook_test). Production charts and config/default use Fail (ACM-38654).
+  # prepare-e2e-test deploys this ValidatingWebhookConfiguration but does not
+  # kind-load the controller image or wait for mtv-integrations-controller; Plan
+  # CREATE/UPDATE from e2e (e.g. plan_ownership) would otherwise fail with
+  # "connection refused" to mtv-plan-webhook-service. webhook-test still exercises
+  # real admission because the in-cluster pod is Available there — Ignore only
+  # fail-opens when the webhook endpoint is unreachable, not when it responds.
+  failurePolicy: Ignore
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/test/resources/e2e/plan_webhook_failurepolicy_ignore.yaml
+++ b/test/resources/e2e/plan_webhook_failurepolicy_ignore.yaml
@@ -1,0 +1,35 @@
+# AI / maintainers: e2e-only ValidatingWebhookConfiguration (failurePolicy: Ignore).
+#
+# Applied by prepare-e2e-test AFTER config/webhook_test (which keeps production-like
+# failurePolicy: Fail for webhook-test). prepare-e2e-test does not kind-load the
+# controller image or wait for mtv-integrations-controller Ready, so Plan
+# CREATE/UPDATE (e.g. plan_ownership) would get "connection refused" to
+# mtv-plan-webhook-service under Fail. This overlay fail-opens only when the
+# webhook endpoint is unreachable; do not use it in prepare-webhook-test.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: open-cluster-management/mtv-plan-webhook-serving-cert
+  name: mtv-plan-webhook-validating-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: mtv-plan-webhook-service
+      namespace: open-cluster-management
+      path: /validate-plan
+  failurePolicy: Ignore
+  name: validate.mtv.plan
+  rules:
+  - apiGroups:
+    - forklift.konveyor.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - plans
+  sideEffects: None


### PR DESCRIPTION
## Summary
- change plan ValidatingWebhookConfiguration `failurePolicy` from `Ignore` to `Fail`
- apply the same change in chart template and default/test webhook manifests
- ensure plan authorization validation fails closed when webhook backend is unavailable

## Test plan
- [x] verify `charts/templates/mtv-integrations-validating-config.yaml` uses `failurePolicy: Fail`
- [x] verify `config/default/webhook.yaml` uses `failurePolicy: Fail`
- [x] verify `config/webhook_test/webhook.yaml` uses `failurePolicy: Fail`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Validating webhooks now reject requests when the webhook cannot be reached, strengthening configuration validation.
  * End-to-end test environments retain fail-open behavior for plan validation when the webhook is unavailable.
* **Testing**
  * End-to-end setup now automatically applies the test-specific webhook configuration, improving test reliability in environments with unavailable webhooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->