### PR TITLE
[ACM-38870] Set plan validating webhook failurePolicy to Fail

### DIFF
--- a/charts/templates/mtv-integrations-validating-config.yaml
+++ b/charts/templates/mtv-integrations-validating-config.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: {{ .Values.global.namespace }}
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/default/webhook.yaml
+++ b/config/default/webhook.yaml
@@ -31,7 +31,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:

--- a/config/webhook_test/webhook.yaml
+++ b/config/webhook_test/webhook.yaml
@@ -54,7 +54,7 @@ webhooks:
       name: mtv-plan-webhook-service
       namespace: open-cluster-management
       path: /validate-plan
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: validate.mtv.plan
   rules:
   - apiGroups:


### PR DESCRIPTION
## Summary
- backport webhook hardening to release-2.16
- change plan ValidatingWebhookConfiguration `failurePolicy` from `Ignore` to `Fail`
- update chart template and default/test webhook manifests consistently

## Test plan
- [x] verify `charts/templates/mtv-integrations-validating-config.yaml` uses `failurePolicy: Fail`
- [x] verify `config/default/webhook.yaml` uses `failurePolicy: Fail`
- [x] verify `config/webhook_test/webhook.yaml` uses `failurePolicy: Fail`

Made with [Cursor](https://cursor.com)