### PR TITLE
fix(webhook): avoid shared mutable rest.Config across concurrent Plan admission requests (release-2.17)

### DIFF
--- a/webhook/plan_webhook.go
+++ b/webhook/plan_webhook.go
@@ -106,8 +106,24 @@ func impersonatedConfig(base rest.Config, userInfo authenticationv1.UserInfo) *r
 		UserName: userInfo.Username,
 		Groups:   userInfo.Groups,
 		UID:      userInfo.UID,
+		Extra:    copyExtra(userInfo.Extra),
 	}
 	return &cfg
+}
+
+// copyExtra converts UserInfo.Extra (map[string]authenticationv1.ExtraValue) into the
+// map[string][]string shape rest.ImpersonationConfig.Extra expects. Dropping Extra would let the
+// downstream authorization check see an incomplete requester identity, so every key/value is
+// carried over; slices are copied so the result never shares backing storage with the request.
+func copyExtra(extra map[string]authenticationv1.ExtraValue) map[string][]string {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(extra))
+	for k, v := range extra {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
 }
 
 func rawToPlan(rawExt runtime.RawExtension) (*v1beta1.Plan, error) {

--- a/webhook/plan_webhook.go
+++ b/webhook/plan_webhook.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
 	v1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -67,13 +68,7 @@ func ValidateWebhook(c client.Client, config rest.Config) *webhook.Admission {
 
 				log = log.WithValues("cluster", clusterName, "namespace", targetNamespace)
 
-				config.Impersonate = rest.ImpersonationConfig{
-					UserName: req.UserInfo.Username,
-					Groups:   req.UserInfo.Groups,
-					UID:      req.UserInfo.UID,
-				}
-
-				dynamicClient, err := dynamic.NewForConfig(&config)
+				dynamicClient, err := dynamic.NewForConfig(impersonatedConfig(config, req.UserInfo))
 				if err != nil {
 					log.Error(err, "Failed to initialize dynamic client with impersonation")
 					return webhook.Denied("Failed to setup dynamic client")
@@ -95,6 +90,24 @@ func ValidateWebhook(c client.Client, config rest.Config) *webhook.Admission {
 			return webhook.Allowed("Plan validation passed")
 		}),
 	}
+}
+
+// impersonatedConfig returns a copy of base with Impersonate set for userInfo.
+//
+// The Handler is invoked concurrently for every admission request but closes over a single
+// shared rest.Config. Mutating that shared value in place (e.g. `config.Impersonate = ...`)
+// races across concurrent goroutines: one request's assignment can be overwritten by another's
+// before dynamic.NewForConfig snapshots it, letting a request's authorization check run under
+// the wrong user's identity. Returning a per-request copy here keeps each request's config
+// independent so concurrent requests can never observe or clobber each other's impersonation.
+func impersonatedConfig(base rest.Config, userInfo authenticationv1.UserInfo) *rest.Config {
+	cfg := base
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: userInfo.Username,
+		Groups:   userInfo.Groups,
+		UID:      userInfo.UID,
+	}
+	return &cfg
 }
 
 func rawToPlan(rawExt runtime.RawExtension) (*v1beta1.Plan, error) {

--- a/webhook/plan_webhook_test.go
+++ b/webhook/plan_webhook_test.go
@@ -2,14 +2,18 @@ package webhook
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
 )
 
 func TestBindingNamespacesCoverTarget(t *testing.T) {
@@ -267,6 +271,46 @@ func TestRawToPlan(t *testing.T) {
 		_, err := rawToPlan(runtime.RawExtension{Raw: []byte(`{`)})
 		require.Error(t, err)
 	})
+}
+
+// TestImpersonatedConfig_ConcurrentRequestsDoNotRace guards against regressing to a design where
+// the admission handler mutates a single shared rest.Config in place. That pattern lets one
+// request's Impersonate assignment be clobbered by a concurrent request before it's used,
+// causing an authorization check to run under the wrong user's identity. impersonatedConfig
+// must instead return an independent copy per call, so concurrent callers can neither observe
+// nor overwrite each other's impersonation identity. Run with `-race` to catch any reintroduced
+// shared mutable state.
+func TestImpersonatedConfig_ConcurrentRequestsDoNotRace(t *testing.T) {
+	t.Parallel()
+	base := rest.Config{Host: "https://hub.example.com"}
+
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			user := fmt.Sprintf("user-%d", i)
+			cfg := impersonatedConfig(base, authenticationv1.UserInfo{
+				Username: user,
+				Groups:   []string{fmt.Sprintf("group-%d", i)},
+				UID:      fmt.Sprintf("uid-%d", i),
+			})
+			if cfg.Impersonate.UserName != user {
+				errs[i] = fmt.Errorf("goroutine %d: got impersonated user %q, want %q", i, cfg.Impersonate.UserName, user)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+
+	// The base config read by every goroutine above must remain untouched: per-request
+	// impersonation must never leak back into the value every request reads from.
+	assert.Equal(t, rest.ImpersonationConfig{}, base.Impersonate)
 }
 
 // userPermissionObject builds a cluster-scoped UserPermission unstructured for the fake dynamic client.

--- a/webhook/plan_webhook_test.go
+++ b/webhook/plan_webhook_test.go
@@ -292,25 +292,60 @@ func TestImpersonatedConfig_ConcurrentRequestsDoNotRace(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			user := fmt.Sprintf("user-%d", i)
+			extraKey := fmt.Sprintf("extra-%d", i)
+			extraVal := fmt.Sprintf("val-%d", i)
 			cfg := impersonatedConfig(base, authenticationv1.UserInfo{
 				Username: user,
 				Groups:   []string{fmt.Sprintf("group-%d", i)},
 				UID:      fmt.Sprintf("uid-%d", i),
+				Extra:    map[string]authenticationv1.ExtraValue{extraKey: {extraVal}},
 			})
-			if cfg.Impersonate.UserName != user {
+			switch {
+			case cfg.Impersonate.UserName != user:
 				errs[i] = fmt.Errorf("goroutine %d: got impersonated user %q, want %q", i, cfg.Impersonate.UserName, user)
+			case len(cfg.Impersonate.Extra[extraKey]) != 1 || cfg.Impersonate.Extra[extraKey][0] != extraVal:
+				errs[i] = fmt.Errorf("goroutine %d: got impersonated extra %v, want {%q: [%q]}",
+					i, cfg.Impersonate.Extra, extraKey, extraVal)
 			}
 		}(i)
 	}
 	wg.Wait()
 
-	for _, err := range errs {
-		assert.NoError(t, err)
+	for i, err := range errs {
+		assert.NoError(t, err, "request %d must retain its own impersonated identity, including UserInfo.Extra", i)
 	}
 
 	// The base config read by every goroutine above must remain untouched: per-request
 	// impersonation must never leak back into the value every request reads from.
-	assert.Equal(t, rest.ImpersonationConfig{}, base.Impersonate)
+	assert.Equal(t, rest.ImpersonationConfig{}, base.Impersonate,
+		"the shared base configuration must remain unchanged by any per-request impersonation copy")
+}
+
+func TestCopyExtra(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, copyExtra(nil))
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, copyExtra(map[string]authenticationv1.ExtraValue{}))
+	})
+
+	t.Run("copies keys and values without sharing backing storage", func(t *testing.T) {
+		t.Parallel()
+		src := map[string]authenticationv1.ExtraValue{
+			"scopes": {"read", "write"},
+		}
+		got := copyExtra(src)
+		require.Equal(t, map[string][]string{"scopes": {"read", "write"}}, got)
+
+		// Mutating the copy must not affect the source ExtraValue slice.
+		got["scopes"][0] = "mutated"
+		assert.Equal(t, authenticationv1.ExtraValue{"read", "write"}, src["scopes"])
+	})
 }
 
 // userPermissionObject builds a cluster-scoped UserPermission unstructured for the fake dynamic client.

--- a/webhook/plan_webhook_test.go
+++ b/webhook/plan_webhook_test.go
@@ -292,17 +292,23 @@ func TestImpersonatedConfig_ConcurrentRequestsDoNotRace(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			user := fmt.Sprintf("user-%d", i)
+			group := fmt.Sprintf("group-%d", i)
+			uid := fmt.Sprintf("uid-%d", i)
 			extraKey := fmt.Sprintf("extra-%d", i)
 			extraVal := fmt.Sprintf("val-%d", i)
 			cfg := impersonatedConfig(base, authenticationv1.UserInfo{
 				Username: user,
-				Groups:   []string{fmt.Sprintf("group-%d", i)},
-				UID:      fmt.Sprintf("uid-%d", i),
+				Groups:   []string{group},
+				UID:      uid,
 				Extra:    map[string]authenticationv1.ExtraValue{extraKey: {extraVal}},
 			})
 			switch {
 			case cfg.Impersonate.UserName != user:
 				errs[i] = fmt.Errorf("goroutine %d: got impersonated user %q, want %q", i, cfg.Impersonate.UserName, user)
+			case len(cfg.Impersonate.Groups) != 1 || cfg.Impersonate.Groups[0] != group:
+				errs[i] = fmt.Errorf("goroutine %d: got groups %v, want [%q]", i, cfg.Impersonate.Groups, group)
+			case cfg.Impersonate.UID != uid:
+				errs[i] = fmt.Errorf("goroutine %d: got UID %q, want %q", i, cfg.Impersonate.UID, uid)
 			case len(cfg.Impersonate.Extra[extraKey]) != 1 || cfg.Impersonate.Extra[extraKey][0] != extraVal:
 				errs[i] = fmt.Errorf("goroutine %d: got impersonated extra %v, want {%q: [%q]}",
 					i, cfg.Impersonate.Extra, extraKey, extraVal)
@@ -312,7 +318,7 @@ func TestImpersonatedConfig_ConcurrentRequestsDoNotRace(t *testing.T) {
 	wg.Wait()
 
 	for i, err := range errs {
-		assert.NoError(t, err, "request %d must retain its own impersonated identity, including UserInfo.Extra", i)
+		assert.NoError(t, err, "request %d must retain its own impersonated identity, including Groups, UID, and Extra", i)
 	}
 
 	// The base config read by every goroutine above must remain untouched: per-request
@@ -326,12 +332,12 @@ func TestCopyExtra(t *testing.T) {
 
 	t.Run("nil input returns nil", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, copyExtra(nil))
+		assert.Nil(t, copyExtra(nil), "nil Extra input must remain nil")
 	})
 
 	t.Run("empty input returns nil", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, copyExtra(map[string]authenticationv1.ExtraValue{}))
+		assert.Nil(t, copyExtra(map[string]authenticationv1.ExtraValue{}), "empty Extra input must return nil")
 	})
 
 	t.Run("copies keys and values without sharing backing storage", func(t *testing.T) {
@@ -340,11 +346,13 @@ func TestCopyExtra(t *testing.T) {
 			"scopes": {"read", "write"},
 		}
 		got := copyExtra(src)
-		require.Equal(t, map[string][]string{"scopes": {"read", "write"}}, got)
+		require.Equal(t, map[string][]string{"scopes": {"read", "write"}}, got,
+			"copyExtra must preserve Extra keys and values")
 
 		// Mutating the copy must not affect the source ExtraValue slice.
 		got["scopes"][0] = "mutated"
-		assert.Equal(t, authenticationv1.ExtraValue{"read", "write"}, src["scopes"])
+		assert.Equal(t, authenticationv1.ExtraValue{"read", "write"}, src["scopes"],
+			"mutating the copied values must not change the source")
 	})
 }
 


### PR DESCRIPTION
Jira: [ACM-38866](https://redhat.atlassian.net/browse/ACM-38866)

Backport of #394 to `release-2.17`.

## Summary
- The Plan validating webhook's admission handler closes over a single `rest.Config` value and mutated its `Impersonate` field in place on every request. Because `controller-runtime` invokes the handler concurrently for different admission requests, this created a race: one request's impersonation identity could be overwritten by another's before `dynamic.NewForConfig` snapshotted it, letting an authorization check run under the wrong user's identity.
- Extracted `impersonatedConfig`, which returns a fresh, independent copy of the base config with `Impersonate` set for the current request's `UserInfo`, so concurrent requests can no longer observe or clobber each other's identity.
- Added a concurrency regression test that exercises many goroutines under `-race` and asserts the base config is never mutated by a call.
- Preserved `UserInfo.Extra` in the per-request impersonation config via a new `copyExtra` helper.

## Test plan
- [x] `go test ./webhook/... -race` passes
- [x] `golangci-lint run ./webhook/...` passes (0 issues)
- [x] `go vet ./webhook/...` and `gofmt -l webhook/` clean
- [x] Cherry-picked cleanly from `main` (#394) with no conflicts

Made with [Cursor](https://cursor.com)

[ACM-38866]: https://redhat.atlassian.net/browse/ACM-38866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ